### PR TITLE
fix: warning: this URL is not a hyperlink

### DIFF
--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -25,7 +25,7 @@ use primordial::Register;
 
 /// `get_attestation` syscall number
 ///
-/// See https://github.com/enarx/enarx-keepldr/issues/31
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
 #[allow(dead_code)]
 pub const SYS_ENARX_GETATT: i64 = 0xEA01;
 
@@ -48,13 +48,13 @@ pub const SYS_ENARX_ERESUME: i64 = -1;
 
 /// `get_attestation` technology return value
 ///
-/// See https://github.com/enarx/enarx-keepldr/issues/31
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
 #[allow(dead_code)]
 pub const SEV_TECH: usize = 1;
 
 /// `get_attestation` technology return value
 ///
-/// See https://github.com/enarx/enarx-keepldr/issues/31
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
 #[allow(dead_code)]
 pub const SGX_TECH: usize = 2;
 


### PR DESCRIPTION
```
  --> src/syscall/mod.rs:28:9
   |
28 | /// See https://github.com/enarx/enarx-keepldr/issues/31
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/enarx/enarx-keepldr/issues/31>`
   |
   = note: `#[warn(rustdoc::bare_urls)]` on by default
   = note: bare URLs are not automatically turned into clickable links
```

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
