### PR TITLE
fix: guard asm code behind asm feauture

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,18 @@ jobs:
       matrix:
         toolchain:
           - nightly
-          - beta
           - stable
-          - 1.41.0
+          - 1.45.0
+        features:
+          -
         profile:
           - name: debug
           - name: release
             flag: --release
+        include:
+          - toolchain: nightly
+            features: asm
+            profile: {name: debug}
+          - toolchain: nightly
+            features: asm
+            profile: {name: release, flag: --release}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "enarx/sallyport" }
 is-it-maintained-open-issues = { repository = "enarx/sallyport" }
 
+[features]
+default = []
+asm = []
+
 [dependencies]
 libc = { version = "0.2", features = [] }
 primordial = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! 1. The shim examines the `Reply` in the `Message` header of the `Block` and propagates any mutated data back to
 //! the protected address space. It may then return control to its workload.
 
-#![feature(asm)]
+#![cfg_attr(feature = "asm", feature(asm))]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 #![cfg_attr(not(test), no_std)]
@@ -191,6 +191,7 @@ impl Request {
     /// # Safety
     ///
     /// This function is unsafe because syscalls can't be made generically safe.
+    #[cfg(feature = "asm")]
     pub unsafe fn syscall(&self) -> Reply {
         let rax: usize;
         let rdx: usize;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,6 +30,7 @@ fn buf_capacity() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+#[cfg(feature = "asm")]
 fn syscall() {
     // Test syscall failure, including bidirectional conversion.
     let req = request!(libc::SYS_close => -1isize);


### PR DESCRIPTION
For non-nightly code to use sallyport.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
