### PR TITLE
fix: clippy error: returning the result of a `let` binding from a block

### DIFF
--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -156,7 +156,7 @@ pub trait SyscallHandler:
         f: Register<usize>,
         nr: usize,
     ) -> Result {
-        let ret = match nr as _ {
+        match nr as _ {
             // MemorySyscallHandler
             libc::SYS_brk => self.brk(a.into()),
             libc::SYS_mmap => self.mmap(
@@ -284,8 +284,6 @@ pub trait SyscallHandler:
 
                 Err(libc::ENOSYS)
             }
-        };
-
-        ret
+        }
     }
 }


### PR DESCRIPTION
```
error: returning the result of a `let` binding from a block
   --> src/syscall/mod.rs:305:9
    |
175 | /         let ret = match nr as _ {
176 | |             // MemorySyscallHandler
177 | |             libc::SYS_brk => self.brk(a.into()),
178 | |             libc::SYS_mmap => self.mmap(
...   |
302 | |             }
303 | |         };
    | |__________- unnecessary `let` binding
304 |
305 |           ret
    |           ^^^
    |
```

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
