### PR TITLE
feat: use programm header flags instead of types

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -10,20 +10,6 @@ pub mod pt {
     /// load the executable. The executable must be loaded at the start of the
     /// region and must (obviously) fit in the region.
     pub const EXEC: u32 = PT_LOOS + 0x3400000;
-
-    /// KVM Program Headers Types
-    pub mod kvm {
-        use super::PT_LOOS;
-
-        /// The sallyport program header type
-        pub const SALLYPORT: u32 = PT_LOOS + 0x34a0001;
-
-        /// The enarx cpuid page program header type
-        pub const CPUID: u32 = PT_LOOS + 0x34a0002;
-
-        /// The enarx secrets page program header type
-        pub const SECRET: u32 = PT_LOOS + 0x34a0003;
-    }
 }
 
 /// Program Header Flags
@@ -35,6 +21,21 @@ pub mod pf {
 
         /// This segment contains unmeasured pages.
         pub const UNMEASURED: u32 = 1 << 21;
+    }
+
+    /// KVM Program Headers Flags
+    pub mod kvm {
+        /// This segment contains the initial sallyport blocks.
+        pub const SALLYPORT: u32 = 1 << 22;
+    }
+
+    /// SNP Program Headers Flags
+    pub mod snp {
+        /// This segment contains cpuid page.
+        pub const CPUID: u32 = 1 << 23;
+
+        /// This segment contains the SNP secrets page.
+        pub const SECRETS: u32 = 1 << 24;
     }
 }
 


### PR DESCRIPTION
For the new enarx keep loader, using flags instead of types suits better
for some PT_LOAD segments.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
