### PR TITLE
Redesign

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           MIRIFLAGS: "-Zmiri-disable-isolation"
         with:
           command: miri
-          args: test --manifest-path ${{ matrix.manifest-path }}
+          args: test --no-default-features --manifest-path ${{ matrix.manifest-path }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/v2/Cargo.toml
+++ b/src/v2/Cargo.toml
@@ -26,3 +26,6 @@ asm = []
 
 [dependencies]
 libc = { version = "0.2", features = [] }
+
+[dev-dependencies]
+serial_test = "0.5"

--- a/src/v2/Cargo.toml
+++ b/src/v2/Cargo.toml
@@ -21,7 +21,7 @@ is-it-maintained-issue-resolution = { repository = "enarx/sallyport" }
 is-it-maintained-open-issues = { repository = "enarx/sallyport" }
 
 [features]
-default = []
+default = [ "asm" ]
 asm = []
 
 [dependencies]

--- a/src/v2/src/guest/alloc/mod.rs
+++ b/src/v2/src/guest/alloc/mod.rs
@@ -38,11 +38,11 @@ pub trait Allocator {
     fn section<T>(&mut self, f: impl FnOnce(&mut Self) -> Result<T>) -> Result<(T, usize)>;
 
     /// Attempts to allocate an arbitrary input [`Layout`]
-    /// and returns corresponding [`InputRef`] on success.
+    /// and returns corresponding [`InRef`] on success.
     fn allocate_input_layout<'a>(&mut self, layout: Layout) -> Result<InRef<'a, [u8]>>;
 
     /// Attempts to allocate an arbitrary output [`Layout`]
-    /// and returns corresponding [`OutputRef`] on success.
+    /// and returns corresponding [`OutRef`] on success.
     fn allocate_output_layout<'a>(&mut self, layout: Layout) -> Result<OutRef<'a, [u8]>>;
 
     /// Attempts to allocate an arbitrary inout [`Layout`]
@@ -50,7 +50,7 @@ pub trait Allocator {
     fn allocate_inout_layout<'a>(&mut self, layout: Layout) -> Result<InOutRef<'a, [u8]>>;
 
     /// Attempts to allocate an input of type `T`
-    /// and returns corresponding [`InputRef`] on success.
+    /// and returns corresponding [`InRef`] on success.
     #[inline]
     fn allocate_input<'a, T>(&mut self) -> Result<InRef<'a, T>> {
         self.allocate_input_layout(Layout::new::<T>())
@@ -58,7 +58,7 @@ pub trait Allocator {
     }
 
     /// Attempts to allocate an output of type `T`
-    /// and returns corresponding [`OutputRef`] on success.
+    /// and returns corresponding [`OutRef`] on success.
     #[inline]
     fn allocate_output<'a, T>(&mut self) -> Result<OutRef<'a, T>> {
         self.allocate_output_layout(Layout::new::<T>())
@@ -74,7 +74,7 @@ pub trait Allocator {
     }
 
     /// Attempts to allocate a slice input of `len` elements of type `T`
-    /// and returns corresponding [`InputRef`] on success.
+    /// and returns corresponding [`InRef`] on success.
     #[inline]
     fn allocate_input_slice<'a, T>(&mut self, len: usize) -> Result<InRef<'a, [T]>> {
         self.allocate_input_layout(array_layout::<T>(len)?)
@@ -82,7 +82,7 @@ pub trait Allocator {
     }
 
     /// Attempts to allocate a slice input of at most `len` elements of type `T` depending on capacity
-    /// and returns corresponding [`InputRef`] on success.
+    /// and returns corresponding [`InRef`] on success.
     #[inline]
     fn allocate_input_slice_max<'a, T>(&mut self, len: usize) -> Result<InRef<'a, [T]>> {
         let len = len.min(self.free::<T>());
@@ -93,7 +93,7 @@ pub trait Allocator {
     }
 
     /// Attempts to allocate a slice output of `len` elements of type `T`
-    /// and returns corresponding [`OutputRef`] on success.
+    /// and returns corresponding [`OutRef`] on success.
     #[inline]
     fn allocate_output_slice<'a, T>(&mut self, len: usize) -> Result<OutRef<'a, [T]>> {
         self.allocate_output_layout(array_layout::<T>(len)?)
@@ -101,7 +101,7 @@ pub trait Allocator {
     }
 
     /// Attempts to allocate a slice output of at most `len` elements of type `T` depending on capacity
-    /// and returns corresponding [`OutputRef`] on success.
+    /// and returns corresponding [`OutRef`] on success.
     #[inline]
     fn allocate_output_slice_max<'a, T>(&mut self, len: usize) -> Result<OutRef<'a, [T]>> {
         let len = len.min(self.free::<T>());

--- a/src/v2/src/guest/alloc/tests.rs
+++ b/src/v2/src/guest/alloc/tests.rs
@@ -34,22 +34,31 @@ fn alloc() {
     assert_eq!(alloc.free::<usize>(), USIZE_COUNT);
     assert_eq!(alloc.free::<u8>(), free);
 
-    let in_u32 = Input::stage(&mut alloc, 0xdeadbeefu32).unwrap();
+    let in_u32 = Input::stage(&mut alloc, 0xdeadbeef_u32).unwrap();
     free -= size_of::<u32>();
     assert_eq!(alloc.free::<usize>(), USIZE_COUNT - 1);
     assert_eq!(alloc.free::<u8>(), free);
     assert_eq!(in_u32.offset(), offset);
     offset += size_of::<u32>();
 
-    let out_u16 = Output::stage(&mut alloc, 0x8888u16).unwrap();
+    let out_u16 = Output::stage(&mut alloc, 0x8888_u16).unwrap();
     free -= size_of::<u16>();
     assert_eq!(alloc.free::<usize>(), USIZE_COUNT - 1);
     assert_eq!(alloc.free::<u8>(), free);
     assert_eq!(out_u16.offset(), offset);
     offset += size_of::<u16>();
 
-    let in_slice_u32 =
-        Input::stage_slice(&mut alloc, [0xaaaaaaaau32, 0x00, 0x00, 0x00, 0x00]).unwrap();
+    let in_slice_u32 = Input::stage_slice(
+        &mut alloc,
+        [
+            0xaaaaaaaa_u32,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+        ],
+    )
+    .unwrap();
     assert_eq!(in_slice_u32.len(), 5);
     free -= size_of::<u16>() + 5 * size_of::<u32>();
     offset += size_of::<u16>();
@@ -58,7 +67,7 @@ fn alloc() {
     assert_eq!(in_slice_u32.offset(), offset);
     offset += 5 * size_of::<u32>();
 
-    let out_slice_u8 = Output::stage_slice(&mut alloc, [0x88u8, 0x88, 0x88, 0x88]).unwrap();
+    let out_slice_u8 = Output::stage_slice(&mut alloc, [0x88_u8, 0x88, 0x88, 0x88]).unwrap();
     assert_eq!(out_slice_u8.len(), 4);
     free -= 4;
     assert_eq!(alloc.free::<usize>(), USIZE_COUNT - 4);
@@ -126,7 +135,7 @@ fn alloc() {
 
     assert_eq!(out_u16.collect(&alloc), 0xfeed);
     assert_eq!(out_slice_u8.collect(&alloc), [0x11, 0x22, 0x33, 0x44]);
-    let mut out_slice_max_usize_got = [0usize; USIZE_COUNT];
+    let mut out_slice_max_usize_got = [0_usize; USIZE_COUNT];
     unsafe {
         out_slice_max_usize.copy_to_unchecked(
             &alloc,

--- a/src/v2/src/guest/alloc/tests.rs
+++ b/src/v2/src/guest/alloc/tests.rs
@@ -2,7 +2,24 @@
 
 use super::*;
 
+use core::fmt::LowerHex;
 use core::mem::size_of;
+
+fn assert_block_eq<const N: usize>(got: [usize; N], expected: [usize; N]) {
+    #[inline]
+    fn format(iter: impl IntoIterator<Item = impl LowerHex>) -> String {
+        iter.into_iter().fold(String::from("\n[\n"), |s, el| {
+            format!("{} {:#018x},\n", s, el)
+        }) + "]\n"
+    }
+    assert_eq!(
+        got,
+        expected,
+        "\ngot: {}\nexpected: {}",
+        format(got),
+        format(expected),
+    );
+}
 
 #[test]
 fn alloc() {
@@ -63,7 +80,7 @@ fn alloc() {
     unsafe { in_out_slice_max_usize.copy_from_unchecked(&alloc, [0x11, 0x22, 0x33]) };
     let out_slice_max_usize = in_out_slice_max_usize.commit(&alloc);
 
-    assert_eq!(
+    assert_block_eq(
         unsafe { buf_ptr.read() },
         [
             0xffffffffdeadbeef,

--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::alloc::{phase, Alloc, Allocator, Collect, Commit, Committer, Stage};
+use super::{syscall, Platform};
+use crate::{item, Result};
+
+use libc::{c_int, ENOSYS};
+
+pub trait Execute {
+    type Platform: Platform;
+    type Allocator: Allocator;
+
+    fn platform(&mut self) -> &mut Self::Platform;
+
+    fn allocator(&mut self) -> Self::Allocator;
+
+    /// Executes an arbitrary call.
+    /// Examples of calls that this method can execute are:
+    /// - [`syscall::Exit`]
+    fn execute<'a, T>(
+        &mut self,
+        req: impl Stage<'a, Item = impl Commit<Item = impl Collect<Item = T>>>,
+    ) -> Result<T> {
+        let mut alloc = self.allocator();
+        let ((staged, len), mut end_ref) =
+            alloc.reserve_input(|alloc| alloc.section(|alloc| req.stage(alloc)))?;
+
+        let alloc = alloc.commit();
+        let committed = staged.commit(&alloc);
+        if len > 0 {
+            end_ref.copy_from(
+                &alloc,
+                item::Header {
+                    kind: item::Kind::End,
+                    size: 0,
+                },
+            );
+            self.platform().sally()?;
+        }
+
+        let alloc = alloc.collect();
+        Ok(committed.collect(&alloc))
+    }
+
+    /// Loops infinitely trying to exit.
+    fn attacked(&mut self) -> ! {
+        loop {
+            let _ = self.exit(1);
+        }
+    }
+
+    /// Executes a supported syscall expressed as an opaque 7-word array akin to [`libc::syscall`].
+    unsafe fn syscall(&mut self, registers: [usize; 7]) -> Result<[usize; 2]> {
+        let [num, argv @ ..] = registers;
+        match (num as _, argv) {
+            (libc::SYS_exit, [status, ..]) => self.exit(status as _).map(|_| self.attacked()),
+            _ => Err(ENOSYS),
+        }
+    }
+
+    /// Executes [`exit`](https://man7.org/linux/man-pages/man2/exit.2.html) syscall akin to [`libc::exit`].
+    fn exit(&mut self, status: c_int) -> Result<()> {
+        self.execute(syscall::Exit { status })?;
+        self.attacked()
+    }
+}
+
+/// Guest request handler.
+pub struct Handler<'a, P: Platform> {
+    alloc: Alloc<'a, phase::Init>,
+    platform: P,
+}
+
+impl<'a, P: Platform> Handler<'a, P> {
+    /// Creates a new [`Handler`] given a mutable borrow of the sallyport block and a [`Platform`].
+    pub fn new(block: &'a mut [usize], platform: P) -> Self {
+        Self {
+            alloc: Alloc::new(block),
+            platform,
+        }
+    }
+}
+
+impl<'a, P: Platform> Execute for Handler<'a, P> {
+    type Platform = P;
+    type Allocator = Alloc<'a, phase::Stage>;
+
+    fn platform(&mut self) -> &mut Self::Platform {
+        &mut self.platform
+    }
+
+    fn allocator(&mut self) -> Self::Allocator {
+        self.alloc.stage()
+    }
+}

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -18,7 +18,7 @@
 //! This may happen concurrently for `N` staged requests.
 //!
 //! Once this phase is finished, the untrusted sallyport block is ready to be passed to the host for execution
-//! via platform-specific `sally` implementation.
+//! via [platform-specific `sally`](Platform::sally).
 //!
 //! Entities that can be committed implement the [`Commit`](alloc::Commit) trait.
 //!
@@ -41,3 +41,7 @@
 pub mod alloc;
 #[cfg(test)]
 pub mod syscall;
+
+mod platform;
+
+pub use platform::*;

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -2,7 +2,23 @@
 
 //! Guest entrypoint into the sallyport.
 //!
-//! # Phase-based request allocation
+//! The main entrypoint into this module is a long-lived [`Handler`], which allocates the requests
+//! within the untrusted sallyport block, passes control to the host for execution of the block via
+//! [platform-specific `sally`](Platform::sally) and reads the replies once it gets the control
+//! back after verifying the integrity of the block.
+//!
+//! In case the [`Handler`] detects that integrity of the request block is not maintained, it
+//! attempts to [`exit`](`Handler::exit`) immediately and does so in an infinite loop.
+//!
+//! [`Handler`] provides:
+//! - API for execution of an arbitrary call:
+//!     - [`execute`](Handler::execute)
+//!
+//! - [`libc`]-like API for syscall execution using safe Rust abstractions where possible, for example:
+//!     - [`syscall`](Handler::syscall) corresponding to [`libc::syscall`].
+//!     - [`exit`](Handler::exit) corresponding to [`libc::exit`].
+//!
+//! # Call lifetime phases
 //!
 //! The crate identifies 3 distinct phases of an arbitrary call lifetime:
 //!
@@ -37,11 +53,11 @@
 //! [output references]: alloc::OutRef
 
 #[allow(clippy::len_without_is_empty)]
-#[cfg(test)]
 pub mod alloc;
-#[cfg(test)]
 pub mod syscall;
 
+mod handler;
 mod platform;
 
+pub use handler::*;
 pub use platform::*;

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -16,6 +16,7 @@
 //!
 //! - [`libc`]-like API for syscall execution using safe Rust abstractions where possible, for example:
 //!     - [`syscall`](Handler::syscall) corresponding to [`libc::syscall`].
+//!     - [`read`](Handler::read) corresponding to [`libc::read`].
 //!     - [`exit`](Handler::exit) corresponding to [`libc::exit`].
 //!
 //! # Call lifetime phases

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -33,8 +33,8 @@
 //! Entities that can be collected implement the [`Collect`](alloc::Collect) trait.
 //!
 //! [inout references]: alloc::InOutRef
-//! [input references]: alloc::InputRef
-//! [output references]: alloc::OutputRef
+//! [input references]: alloc::InRef
+//! [output references]: alloc::OutRef
 
 #[allow(clippy::len_without_is_empty)]
 #[cfg(test)]

--- a/src/v2/src/guest/platform.rs
+++ b/src/v2/src/guest/platform.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libc::c_int;
+
+/// Platform-specific functionality.
+pub trait Platform {
+    /// Suspend guest execution and pass control to host.
+    /// This function will return when the host passes control back to the guest.
+    fn sally(&mut self) -> Result<(), c_int>;
+
+    /// Validates that a region of memory is valid for read-write access.
+    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    fn validate_mut<'a, T>(&self, ptr: usize) -> Result<&'a mut T, c_int>;
+
+    /// Validates that a region of memory is valid for read-only access.
+    /// Returns an immutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    fn validate<'a, T>(&self, ptr: usize) -> Result<&'a T, c_int> {
+        self.validate_mut(ptr).map(|v| v as _)
+    }
+
+    /// Validates that a region of memory is valid for read-write access for `len` elements of type `T`.
+    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    fn validate_slice_mut<'a, T>(&self, ptr: usize, len: usize) -> Result<&'a mut [T], c_int>;
+
+    /// Validates that a region of memory is valid for read-only access for `len` elements of type `T`.
+    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    fn validate_slice<'a, T>(&self, ptr: usize, len: usize) -> Result<&'a [T], c_int> {
+        self.validate_slice_mut(ptr, len).map(|v| v as _)
+    }
+}

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -7,8 +7,10 @@ mod tests;
 
 mod argv;
 mod exit;
+mod read;
 mod result;
 
 pub use argv::*;
 pub use exit::*;
+pub use read::*;
 pub use result::*;

--- a/src/v2/src/guest/syscall/read.rs
+++ b/src/v2/src/guest/syscall/read.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Argv;
+use crate::guest::alloc::{Allocator, Collector, Output, Syscall};
+use crate::Result;
+
+use libc::{c_int, c_long, size_t};
+
+pub struct Read<'a> {
+    pub fd: c_int,
+    pub buf: &'a mut [u8],
+}
+
+unsafe impl<'a> Syscall<'a> for Read<'a> {
+    const NUM: c_long = libc::SYS_read;
+    const DEFAULT_RET: Self::Ret = unsafe { super::Result::errno_unchecked(libc::ENOSYS) };
+
+    type Argv = Argv<3>;
+    type Ret = super::Result<size_t>;
+
+    type Staged = Output<'a, [u8], &'a mut [u8]>;
+    type Committed = Self::Staged;
+    type Collected = Option<Result<size_t>>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let (buf, _) = Output::stage_slice_max(alloc, self.buf)?;
+        Ok((Argv([self.fd as _, buf.offset(), buf.len()]), buf))
+    }
+
+    fn collect(
+        committed: Self::Committed,
+        ret: Self::Ret,
+        col: &impl Collector,
+    ) -> Self::Collected {
+        match ret.into() {
+            Ok(ret) if ret > committed.len() => None,
+            res @ Ok(ret) => {
+                unsafe { committed.collect_range(col, 0..ret) };
+                Some(res)
+            }
+            err => Some(err),
+        }
+    }
+}

--- a/src/v2/src/guest/syscall/tests.rs
+++ b/src/v2/src/guest/syscall/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::guest::alloc::{Alloc, Collect, Commit, Stage};
+use crate::guest::alloc::{Alloc, Allocator, Collect, Commit, Committer, Stage};
 use crate::item::{self, SYSCALL_USIZE_COUNT};
 
 use core::marker::PhantomData;

--- a/src/v2/src/host/mod.rs
+++ b/src/v2/src/host/mod.rs
@@ -82,6 +82,9 @@ mod tests {
                     Syscall {
                         num: SYS_read as _,
                         argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
+                        #[cfg(feature = "asm")]
+                        ret: [0, 0],
+                        #[cfg(not(feature = "asm"))]
                         ret: [-ENOSYS as _, 0],
                     },
                     []

--- a/src/v2/src/item/mod.rs
+++ b/src/v2/src/item/mod.rs
@@ -2,7 +2,7 @@
 
 //! Shared `sallyport` item definitions.
 
-use crate::iter::Iterator;
+use crate::iter::{IntoIterator, Iterator};
 use crate::Error;
 
 use core::convert::{TryFrom, TryInto};
@@ -141,6 +141,15 @@ impl<'a> Iterator for Block<'a> {
     #[inline]
     fn next(self) -> Option<(Self::Item, Block<'a>)> {
         self.into()
+    }
+}
+
+impl<'a> IntoIterator for Block<'a> {
+    type Item = <Self as Iterator>::Item;
+    type IntoIter = Self;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self
     }
 }
 

--- a/src/v2/tests/integration_tests.rs
+++ b/src/v2/tests/integration_tests.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env::temp_dir;
+use std::fs::File;
+use std::io::Write;
+use std::os::unix::prelude::AsRawFd;
+use std::ptr::NonNull;
+use std::slice;
+
+use sallyport::guest::{Execute, Handler, Platform};
+use sallyport::item::Block;
+use sallyport::{host, Result};
+use serial_test::serial;
+
+struct TestPlatform<const N: usize>(NonNull<[usize; N]>);
+
+impl<const N: usize> Platform for TestPlatform<N> {
+    fn sally(&mut self) -> Result<()> {
+        host::execute(Block::from(unsafe { &mut self.0.as_mut()[..] }));
+        Ok(())
+    }
+
+    fn validate_mut<'b, T>(&self, ptr: usize) -> Result<&'b mut T> {
+        Ok(unsafe { &mut *(ptr as *mut _) })
+    }
+
+    fn validate_slice_mut<'b, T>(&self, ptr: usize, len: usize) -> Result<&'b mut [T]> {
+        Ok(unsafe { slice::from_raw_parts_mut(ptr as _, len) })
+    }
+}
+
+fn run_test<const N: usize>(
+    n: usize,
+    mut block: [usize; N],
+    f: impl Fn(&mut Handler<TestPlatform<N>>),
+) {
+    let platform = TestPlatform(NonNull::from(&mut block));
+    let mut handler = Handler::new(&mut block, platform);
+    for _ in 0..n {
+        f(&mut handler);
+    }
+    let _ = block;
+}
+
+#[cfg(not(miri))]
+#[test]
+#[serial]
+fn read() {
+    const EXPECTED: &str = "read";
+    let path = temp_dir().join("sallyport-test-read");
+    write!(&mut File::create(&path).unwrap(), "{}", EXPECTED).unwrap();
+
+    run_test(3, [0xff; 16], move |handler| {
+        let mut buf = [0u8; EXPECTED.len()];
+
+        #[cfg(feature = "asm")]
+        let expected_ret = Ok(EXPECTED.len());
+        #[cfg(not(feature = "asm"))]
+        let expected_ret = Err(libc::ENOSYS);
+
+        assert_eq!(
+            handler.read(File::open(&path).unwrap().as_raw_fd(), &mut buf),
+            expected_ret,
+        );
+        #[cfg(feature = "asm")]
+        assert_eq!(buf, EXPECTED.as_bytes());
+    });
+}


### PR DESCRIPTION
Closes enarx/sallyport#17 

Docs at their current state are available at https://rvolosatovs.github.io/universe/rust/sallyport/index.html

This PR is the last one in the series of crate redesign, on top of which actual request handling (e.g. syscalls) will be implemented.

## Follow-ups (issues should be filed)
- Syscall implementations (feature-parity as first step) enarx/sallyport#34 https://github.com/enarx/sallyport/pull/20 
- Lint against `unsafe` enarx/enarx#1724 
- (tech debt) Macros for request definitions and possibly reducing boilerplate within the crate, especially for requests without allocations
- (tech debt) Improve documentation enarx/enarx#1725 enarx/sallyport#33 
- (tech debt) Profiling and following optimization of operations on the hot path.
- (tech debt) Use a designated directory for temporary test files, use `O_TMPFILE` where possible/feasible