### PR TITLE
feat: add Enarx gdb extensions

### DIFF
--- a/src/syscall/enarx.rs
+++ b/src/syscall/enarx.rs
@@ -2,12 +2,17 @@
 
 //! enarx syscalls
 
-use crate::untrusted::{UntrustedRef, UntrustedRefMut};
-use crate::Result;
+use crate::syscall::{
+    BaseSyscallHandler, SYS_ENARX_GDB_PEEK, SYS_ENARX_GDB_READ, SYS_ENARX_GDB_START,
+    SYS_ENARX_GDB_WRITE,
+};
+use crate::untrusted::{AddressValidator, UntrustedRef, UntrustedRefMut, ValidateSlice};
+use crate::Register;
+use crate::{request, Block, Result};
 use primordial::Address;
 
 /// enarx syscalls
-pub trait EnarxSyscallHandler {
+pub trait EnarxSyscallHandler: BaseSyscallHandler + AddressValidator + Sized {
     /// Enarx syscall - get attestation
     fn get_attestation(
         &mut self,
@@ -16,6 +21,72 @@ pub trait EnarxSyscallHandler {
         buf: UntrustedRefMut<u8>,
         buf_len: libc::size_t,
     ) -> Result;
+
+    /// gdb extension
+    fn gdb_start(&mut self) -> Result {
+        self.trace("gdb_start", 0);
+        unsafe { self.proxy(request!(SYS_ENARX_GDB_START)) }
+    }
+
+    /// gdb extension
+    fn gdb_read(&mut self, buf: UntrustedRefMut<u8>, count: libc::size_t) -> Result {
+        let buf = buf.validate_slice(count, self).ok_or(libc::EFAULT)?;
+
+        let c = self.new_cursor();
+
+        // Limit the read to `Block::buf_capacity()`
+        let count = usize::min(count, Block::buf_capacity());
+
+        let (_, hostbuf) = c.alloc::<u8>(count).or(Err(libc::EMSGSIZE))?;
+        let hostbuf = hostbuf.as_ptr();
+        let host_virt = Self::translate_shim_to_host_addr(hostbuf);
+
+        let ret = unsafe { self.proxy(request!(SYS_ENARX_GDB_READ => host_virt, count))? };
+
+        let result_len: usize = ret[0].into();
+
+        if count < result_len {
+            self.attacked();
+        }
+
+        let c = self.new_cursor();
+        unsafe {
+            c.copy_into_slice(count, buf[..result_len].as_mut())
+                .or(Err(libc::EFAULT))?;
+        }
+
+        Ok(ret)
+    }
+
+    /// gdb extension
+    fn gdb_peek(&mut self) -> Result {
+        self.trace("gdb_peek", 0);
+        unsafe { self.proxy(request!(SYS_ENARX_GDB_PEEK)) }
+    }
+
+    /// gdb extension
+    fn gdb_write(&mut self, buf: UntrustedRef<u8>, count: libc::size_t) -> Result {
+        //self.trace(">>>> gdb_write", 2);
+        // Limit the write to `Block::buf_capacity()`
+        let count = usize::min(count, Block::buf_capacity());
+
+        let buf = buf.validate_slice(count, self).ok_or(libc::EFAULT)?;
+
+        let c = self.new_cursor();
+        let (_, buf) = c.copy_from_slice(buf.as_ref()).or(Err(libc::EMSGSIZE))?;
+        let buf = buf.as_ptr();
+        let host_virt = Self::translate_shim_to_host_addr(buf);
+
+        let ret = unsafe { self.proxy(request!(SYS_ENARX_GDB_WRITE => host_virt, count))? };
+
+        let result_len: usize = ret[0].into();
+
+        if result_len > count {
+            self.attacked()
+        }
+
+        Ok(ret)
+    }
 }
 
 /// Basic information about the host memory, the shim requests

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -41,6 +41,22 @@ pub const SYS_ENARX_BALLOON_MEMORY: i64 = 0xEA03;
 #[allow(dead_code)]
 pub const SYS_ENARX_CPUID: i64 = 0xEA04;
 
+/// Enarx gdb extension
+#[allow(dead_code)]
+pub const SYS_ENARX_GDB_START: i64 = 0xEA10;
+
+/// Enarx gdb extension
+#[allow(dead_code)]
+pub const SYS_ENARX_GDB_READ: i64 = 0xEA11;
+
+/// Enarx gdb extension
+#[allow(dead_code)]
+pub const SYS_ENARX_GDB_PEEK: i64 = 0xEA12;
+
+/// Enarx gdb extension
+#[allow(dead_code)]
+pub const SYS_ENARX_GDB_WRITE: i64 = 0xEA13;
+
 /// Enarx syscall extension: Resume an enclave after an asynchronous exit
 // Keep in sync with shim-sgx/src/start.S
 #[allow(dead_code)]
@@ -278,6 +294,11 @@ pub trait SyscallHandler:
             ),
 
             SYS_ENARX_GETATT => self.get_attestation(a.into(), b.into(), c.into(), d.into()),
+
+            SYS_ENARX_GDB_START => self.gdb_start(),
+            SYS_ENARX_GDB_PEEK => self.gdb_peek(),
+            SYS_ENARX_GDB_READ => self.gdb_read(a.into(), b.into()),
+            SYS_ENARX_GDB_WRITE => self.gdb_write(a.into(), b.into()),
 
             _ => {
                 self.unknown_syscall(a, b, c, d, e, f, nr);


### PR DESCRIPTION
To enable gdb debugging specialized functions are needed.

Instead of using the normal syscalls, we use these, so that any filter
mechanisms do not have to make exceptions for the gdb connection.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
