### PR TITLE
Don't clear `epoll_ctl()` event data

### DIFF
--- a/src/syscall/file.rs
+++ b/src/syscall/file.rs
@@ -347,9 +347,6 @@ pub trait FileSyscallHandler: BaseSyscallHandler + AddressValidator + Sized {
         let (_, buf) = c.write(event).or(Err(libc::EMSGSIZE))?;
         let host_virt = Self::translate_shim_to_host_addr(buf);
 
-        // clear sensitive user data from the event
-        buf.u64 = fd as _;
-
         let ret = unsafe { self.proxy(request!(libc::SYS_epoll_ctl => epfd, op, fd, host_virt))? };
 
         Ok(ret)


### PR DESCRIPTION
This patch makes the interface work again. But in the process it
discloses some data to the host. We will fix it after shim allocation
lands. The debt bug recording this is available here:

enarx/enarx#1723

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>