### PR TITLE
Remove support for the `pipe()` syscall

### DIFF
--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -225,7 +225,6 @@ pub trait SyscallHandler:
                 usize::from(c) as _,
             ),
             libc::SYS_poll => self.poll(a.into(), b.into(), usize::from(c) as _),
-            libc::SYS_pipe => self.pipe(a.into()),
             libc::SYS_epoll_create1 => self.epoll_create1(a.try_into().map_err(|_| libc::EINVAL)?),
             libc::SYS_epoll_ctl => self.epoll_ctl(
                 usize::from(a) as _,


### PR DESCRIPTION
We can't proxy this syscall to the host as it will disclose all data
that goes over the pipe. Instead, remove support. We will re-add it if
we need it.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>