### PR TITLE
v2: Add host item executor and block iterator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         toolchain:
           - nightly
           - stable
-          - 1.50.0
+          - 1.57.0
         features:
           -
         profile:

--- a/src/v2/Cargo.toml
+++ b/src/v2/Cargo.toml
@@ -20,5 +20,9 @@ maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "enarx/sallyport" }
 is-it-maintained-open-issues = { repository = "enarx/sallyport" }
 
+[features]
+default = []
+asm = []
+
 [dependencies]
 libc = { version = "0.2", features = [] }

--- a/src/v2/src/host/mod.rs
+++ b/src/v2/src/host/mod.rs
@@ -9,6 +9,7 @@ mod syscall;
 use syscall::*;
 
 use crate::item::Item;
+use crate::iter::{IntoIterator, Iterator};
 
 pub(super) trait Execute {
     unsafe fn execute(self);
@@ -19,8 +20,8 @@ impl<'a> Execute for Item<'a> {
     unsafe fn execute(self) {
         match self {
             #[cfg(feature = "asm")]
-            Item::Syscall { ptr, .. } => {
-                let _ = execute_syscall(ptr);
+            Item::Syscall(syscall, data) => {
+                let _ = execute_syscall(syscall, data);
             }
             #[cfg(not(feature = "asm"))]
             Item::Syscall { .. } => {}
@@ -46,51 +47,53 @@ mod tests {
     use super::*;
     use crate::item::Syscall;
 
-    use core::marker::PhantomData;
-    use core::ptr::{slice_from_raw_parts_mut, NonNull};
     use libc::{SYS_fcntl, SYS_read, ENOSYS, F_GETFD, STDIN_FILENO};
 
     #[test]
     fn execute() {
         let mut syscalls = [
-            Syscall {
-                num: SYS_read as _,
-                argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
-                ret: [-ENOSYS as _, 0],
-            },
-            Syscall {
-                num: SYS_fcntl as _,
-                argv: [STDIN_FILENO as _, F_GETFD as _, 0, 0, 0, 0],
-                ret: [-ENOSYS as _, 0],
-            },
-        ];
-        super::execute([
-            Item::Syscall {
-                ptr: unsafe {
-                    NonNull::new_unchecked(slice_from_raw_parts_mut(&mut syscalls[0] as _, 0) as _)
-                },
-                phantom: PhantomData,
-            },
-            Item::Syscall {
-                ptr: unsafe {
-                    NonNull::new_unchecked(slice_from_raw_parts_mut(&mut syscalls[1] as _, 0) as _)
-                },
-                phantom: PhantomData,
-            },
-        ]);
-        assert_eq!(
-            syscalls,
-            [
+            (
                 Syscall {
                     num: SYS_read as _,
                     argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
                     ret: [-ENOSYS as _, 0],
                 },
+                [],
+            ),
+            (
                 Syscall {
                     num: SYS_fcntl as _,
                     argv: [STDIN_FILENO as _, F_GETFD as _, 0, 0, 0, 0],
                     ret: [-ENOSYS as _, 0],
                 },
+                [],
+            ),
+        ];
+        let (first, tail) = syscalls.split_first_mut().unwrap();
+        let (second, _) = tail.split_first_mut().unwrap();
+        super::execute([
+            Item::Syscall(&mut first.0, &mut first.1),
+            Item::Syscall(&mut second.0, &mut second.1),
+        ]);
+        assert_eq!(
+            syscalls,
+            [
+                (
+                    Syscall {
+                        num: SYS_read as _,
+                        argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
+                        ret: [-ENOSYS as _, 0],
+                    },
+                    []
+                ),
+                (
+                    Syscall {
+                        num: SYS_fcntl as _,
+                        argv: [STDIN_FILENO as _, F_GETFD as _, 0, 0, 0, 0],
+                        ret: [-ENOSYS as _, 0],
+                    },
+                    []
+                )
             ]
         );
     }

--- a/src/v2/src/host/mod.rs
+++ b/src/v2/src/host/mod.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Host-specific functionality.
+
+#[cfg(feature = "asm")]
+mod syscall;
+
+#[cfg(feature = "asm")]
+use syscall::*;
+
+use crate::item::Item;
+
+pub(super) trait Execute {
+    unsafe fn execute(self);
+}
+
+impl<'a> Execute for Item<'a> {
+    #[inline]
+    unsafe fn execute(self) {
+        match self {
+            #[cfg(feature = "asm")]
+            Item::Syscall { ptr, .. } => {
+                let _ = execute_syscall(ptr);
+            }
+            #[cfg(not(feature = "asm"))]
+            Item::Syscall { .. } => {}
+        }
+    }
+}
+
+impl<'a, T: IntoIterator<Item = Item<'a>>> Execute for T {
+    #[inline]
+    unsafe fn execute(self) {
+        self.into_iter().for_each(|item| item.execute())
+    }
+}
+
+/// Executes the passed `items`.
+#[inline]
+pub fn execute<'a>(items: impl IntoIterator<Item = Item<'a>>) {
+    unsafe { items.execute() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::Syscall;
+
+    use core::marker::PhantomData;
+    use core::ptr::{slice_from_raw_parts_mut, NonNull};
+    use libc::{SYS_fcntl, SYS_read, ENOSYS, F_GETFD, STDIN_FILENO};
+
+    #[test]
+    fn execute() {
+        let mut syscalls = [
+            Syscall {
+                num: SYS_read as _,
+                argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
+                ret: [-ENOSYS as _, 0],
+            },
+            Syscall {
+                num: SYS_fcntl as _,
+                argv: [STDIN_FILENO as _, F_GETFD as _, 0, 0, 0, 0],
+                ret: [-ENOSYS as _, 0],
+            },
+        ];
+        super::execute([
+            Item::Syscall {
+                ptr: unsafe {
+                    NonNull::new_unchecked(slice_from_raw_parts_mut(&mut syscalls[0] as _, 0) as _)
+                },
+                phantom: PhantomData,
+            },
+            Item::Syscall {
+                ptr: unsafe {
+                    NonNull::new_unchecked(slice_from_raw_parts_mut(&mut syscalls[1] as _, 0) as _)
+                },
+                phantom: PhantomData,
+            },
+        ]);
+        assert_eq!(
+            syscalls,
+            [
+                Syscall {
+                    num: SYS_read as _,
+                    argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
+                    ret: [-ENOSYS as _, 0],
+                },
+                Syscall {
+                    num: SYS_fcntl as _,
+                    argv: [STDIN_FILENO as _, F_GETFD as _, 0, 0, 0, 0],
+                    ret: [-ENOSYS as _, 0],
+                },
+            ]
+        );
+    }
+}

--- a/src/v2/src/host/syscall.rs
+++ b/src/v2/src/host/syscall.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Execute;
+use crate::{item, read_first, Result};
+
+use core::arch::asm;
+use core::ptr::NonNull;
+use libc::c_long;
+
+struct Syscall<const ARGS: usize, const RETS: usize> {
+    /// The syscall number for the request.
+    ///
+    /// See, for example, [`libc::SYS_exit`](libc::SYS_exit).
+    num: c_long,
+
+    /// The syscall argument vector.
+    argv: [usize; ARGS],
+
+    /// Return values.
+    ret: *mut [usize; RETS],
+}
+
+impl Execute for Syscall<0, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+impl Execute for Syscall<1, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        in("rdi") self.argv[0],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+impl Execute for Syscall<2, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        in("rdi") self.argv[0],
+        in("rsi") self.argv[1],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+impl Execute for Syscall<3, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        in("rdi") self.argv[0],
+        in("rsi") self.argv[1],
+        in("rdx") self.argv[2],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+impl Execute for Syscall<4, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        in("rdi") self.argv[0],
+        in("rsi") self.argv[1],
+        in("rdx") self.argv[2],
+        in("r10") self.argv[3],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+impl Execute for Syscall<5, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        in("rdi") self.argv[0],
+        in("rsi") self.argv[1],
+        in("rdx") self.argv[2],
+        in("r10") self.argv[3],
+        in("r8") self.argv[4],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+impl Execute for Syscall<6, 1> {
+    #[inline]
+    unsafe fn execute(self) {
+        asm!(
+        "syscall",
+        inlateout("rax") self.num as usize => (*self.ret)[0],
+        in("rdi") self.argv[0],
+        in("rsi") self.argv[1],
+        in("rdx") self.argv[2],
+        in("r10") self.argv[3],
+        in("r8") self.argv[4],
+        in("r9") self.argv[5],
+        lateout("rcx") _, // clobbered
+        lateout("r11") _, // clobbered
+        )
+    }
+}
+
+pub(super) unsafe fn execute_syscall(ptr: NonNull<(item::Syscall, [u8])>) -> Result<()> {
+    let (num, ptr) = read_first(ptr.cast());
+    match num as _ {
+        libc::SYS_exit => {
+            let (status, ptr) = read_first(NonNull::new_unchecked(ptr));
+            Syscall {
+                num: libc::SYS_exit,
+                argv: [status],
+                ret: ptr.add(5) as _,
+            }
+            .execute()
+        }
+        _ => return Err(libc::ENOSYS),
+    }
+    Ok(())
+}

--- a/src/v2/src/item/mod.rs
+++ b/src/v2/src/item/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::Error;
 
-use core::convert::TryFrom;
+use core::convert::{TryFrom, TryInto};
 use libc::EINVAL;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -31,6 +31,17 @@ impl TryFrom<usize> for Kind {
 pub struct Header {
     pub size: usize,
     pub kind: Kind,
+}
+
+impl TryFrom<[usize; 2]> for Header {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(header: [usize; 2]) -> Result<Self, Self::Error> {
+        let [size, kind] = header;
+        let kind = kind.try_into()?;
+        Ok(Self { size, kind })
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/v2/src/item/mod.rs
+++ b/src/v2/src/item/mod.rs
@@ -1,11 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::Error;
+
+use core::convert::TryFrom;
+use libc::EINVAL;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(usize)]
 pub enum Kind {
     End = 0x00,
 
     Syscall = 0x01,
+}
+
+impl TryFrom<usize> for Kind {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(kind: usize) -> Result<Self, Self::Error> {
+        match kind {
+            kind if kind == Kind::End as _ => Ok(Kind::End),
+            kind if kind == Kind::Syscall as _ => Ok(Kind::Syscall),
+            _ => Err(EINVAL),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/v2/src/item/mod.rs
+++ b/src/v2/src/item/mod.rs
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Error;
+//! Shared `sallyport` item definitions.
+
+use crate::{read_array, Error, SlicePtr};
 
 use core::convert::{TryFrom, TryInto};
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ptr::{slice_from_raw_parts_mut, NonNull};
 use libc::EINVAL;
 
+/// `sallyport` item kind.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(usize)]
 pub enum Kind {
@@ -26,6 +32,7 @@ impl TryFrom<usize> for Kind {
     }
 }
 
+/// `sallyport` item header.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C, align(8))]
 pub struct Header {
@@ -44,10 +51,149 @@ impl TryFrom<[usize; 2]> for Header {
     }
 }
 
+/// Payload of an [Item] of [Kind::Syscall].
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C, align(8))]
 pub struct Syscall {
     pub num: usize,
     pub argv: [usize; 6],
     pub ret: [usize; 2],
+}
+
+/// `sallyport` item.
+#[derive(Debug, PartialEq)]
+#[repr(transparent)]
+pub enum Item<'a> {
+    Syscall {
+        ptr: NonNull<(Syscall, [u8])>,
+        phantom: PhantomData<&'a ()>,
+    },
+}
+
+/// Iterator over untrusted `sallyport` block.
+#[derive(Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Iter<'a>(NonNull<[u8]>, PhantomData<&'a ()>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Item<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let capacity = SlicePtr::len(self.0.as_ptr()).checked_sub(2 * size_of::<usize>())?;
+        let (header, ptr): (_, *mut u8) = unsafe { read_array(self.0.cast()) };
+        let Header { size, kind } = header.try_into().ok()?;
+        match kind {
+            Kind::End => {
+                debug_assert_eq!(size, 0);
+                None
+            }
+
+            Kind::Syscall => {
+                debug_assert_eq!(size % core::mem::align_of::<usize>(), 0);
+                let capacity = capacity.checked_sub(size)?;
+                self.0 = unsafe {
+                    NonNull::new_unchecked(slice_from_raw_parts_mut(ptr.add(size), capacity))
+                };
+                let data_size = size.checked_sub(size_of::<Syscall>())?;
+                Some(Item::Syscall {
+                    ptr: unsafe {
+                        NonNull::new_unchecked(slice_from_raw_parts_mut(ptr, data_size) as _)
+                    },
+                    phantom: PhantomData,
+                })
+            }
+        }
+    }
+}
+
+/// Reference to untrusted `sallyport` block.
+#[derive(Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Block<'a>(NonNull<[u8]>, PhantomData<&'a ()>);
+
+impl<'a, const N: usize> From<NonNull<[usize; N]>> for Block<'a> {
+    #[inline]
+    fn from(buffer: NonNull<[usize; N]>) -> Self {
+        Self(
+            unsafe {
+                NonNull::new_unchecked(slice_from_raw_parts_mut(
+                    buffer.as_ptr() as _,
+                    N * size_of::<usize>(),
+                ))
+            },
+            PhantomData,
+        )
+    }
+}
+
+impl<'a> IntoIterator for Block<'a> {
+    type Item = Item<'a>;
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.0, PhantomData)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::read_one;
+
+    #[test]
+    fn block() {
+        let mut block: [usize; 25] = [
+            10 * size_of::<usize>(), // size
+            Kind::Syscall as _,      // kind
+            libc::SYS_read as _,     // num
+            1,                       // fd
+            0,                       // buf
+            2,                       // count
+            0,                       // -
+            0,                       // -
+            0,                       // -
+            -libc::ENOSYS as _,      // ret
+            0,                       // -
+            0xdeadbeef,              // data
+            /* --------------------- */
+            9 * size_of::<usize>(), // size
+            Kind::Syscall as _,     // kind
+            libc::SYS_exit as _,    // num
+            5,                      // status
+            0,                      // -
+            0,                      // -
+            0,                      // -
+            0,                      // -
+            0,                      // -
+            -libc::ENOSYS as _,     // ret
+            0,                      // -
+            /* --------------------- */
+            0,              // size
+            Kind::End as _, // kind
+        ];
+        let items = Block::from(NonNull::from(&mut block))
+            .into_iter()
+            .collect::<Vec<Item>>();
+
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0], Item::Syscall { ptr, .. } if {
+            let (Syscall{ num, argv, ret }, data): (_, *mut u32) = unsafe {read_one(ptr.cast())};
+            assert_eq!(SlicePtr::len(ptr.as_ptr() as *const [u8]), size_of::<usize>());
+            assert_eq!(num, libc::SYS_read as _);
+            assert_eq!(argv, [1, 0, 2, 0, 0, 0]);
+            assert_eq!(ret, [-libc::ENOSYS as _, 0]);
+            assert_eq!(unsafe{ data.read() }, 0xdeadbeef);
+            true
+        }));
+        assert!(matches!(items[1], Item::Syscall { ptr, .. } if {
+            let (Syscall{ num, argv, ret }, _): (_, *mut ()) = unsafe {read_one(ptr.cast())};
+            assert_eq!(SlicePtr::len(ptr.as_ptr() as *const [u8]), 0);
+            assert_eq!(num, libc::SYS_exit as _);
+            assert_eq!(argv, [5, 0, 0, 0, 0, 0]);
+            assert_eq!(ret, [-libc::ENOSYS as _, 0]);
+            true
+        }));
+    }
 }

--- a/src/v2/src/item/mod.rs
+++ b/src/v2/src/item/mod.rs
@@ -2,12 +2,11 @@
 
 //! Shared `sallyport` item definitions.
 
-use crate::{read_array, Error, SlicePtr};
+use crate::iter::Iterator;
+use crate::Error;
 
 use core::convert::{TryFrom, TryInto};
-use core::marker::PhantomData;
-use core::mem::size_of;
-use core::ptr::{slice_from_raw_parts_mut, NonNull};
+use core::mem::{align_of, size_of};
 use libc::EINVAL;
 
 /// `sallyport` item kind.
@@ -60,140 +59,154 @@ pub struct Syscall {
     pub ret: [usize; 2],
 }
 
-/// `sallyport` item.
-#[derive(Debug, PartialEq)]
-#[repr(transparent)]
-pub enum Item<'a> {
-    Syscall {
-        ptr: NonNull<(Syscall, [u8])>,
-        phantom: PhantomData<&'a ()>,
-    },
+const SYSCALL_USIZE_COUNT: usize = size_of::<Syscall>() / size_of::<usize>();
+
+impl From<&mut [usize; SYSCALL_USIZE_COUNT]> for &mut Syscall {
+    #[inline]
+    fn from(buf: &mut [usize; SYSCALL_USIZE_COUNT]) -> Self {
+        debug_assert_eq!(
+            size_of::<Syscall>(),
+            SYSCALL_USIZE_COUNT * size_of::<usize>()
+        );
+        unsafe { &mut *(buf as *mut _ as *mut _) }
+    }
 }
 
-/// Iterator over untrusted `sallyport` block.
+/// `sallyport` item.
+#[derive(Debug, PartialEq)]
+pub enum Item<'a> {
+    Syscall(&'a mut Syscall, &'a mut [u8]),
+}
+
+/// Untrusted `sallyport` block.
 #[derive(Debug, PartialEq)]
 #[repr(transparent)]
-pub struct Iter<'a>(NonNull<[u8]>, PhantomData<&'a ()>);
+pub struct Block<'a>(&'a mut [usize]);
 
-impl<'a> Iterator for Iter<'a> {
-    type Item = Item<'a>;
-
+impl<'a> From<&'a mut [usize]> for Block<'a> {
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let capacity = SlicePtr::len(self.0.as_ptr()).checked_sub(2 * size_of::<usize>())?;
-        let (header, ptr): (_, *mut u8) = unsafe { read_array(self.0.cast()) };
-        let Header { size, kind } = header.try_into().ok()?;
-        match kind {
-            Kind::End => {
-                debug_assert_eq!(size, 0);
-                None
-            }
+    fn from(block: &'a mut [usize]) -> Self {
+        Self(block)
+    }
+}
 
-            Kind::Syscall => {
-                debug_assert_eq!(size % core::mem::align_of::<usize>(), 0);
-                let capacity = capacity.checked_sub(size)?;
-                self.0 = unsafe {
-                    NonNull::new_unchecked(slice_from_raw_parts_mut(ptr.add(size), capacity))
-                };
-                let data_size = size.checked_sub(size_of::<Syscall>())?;
-                Some(Item::Syscall {
-                    ptr: unsafe {
-                        NonNull::new_unchecked(slice_from_raw_parts_mut(ptr, data_size) as _)
-                    },
-                    phantom: PhantomData,
-                })
+impl<'a> From<Block<'a>> for Option<(Option<Item<'a>>, Block<'a>)> {
+    #[inline]
+    fn from(block: Block<'a>) -> Self {
+        match block.0 {
+            [size, kind, tail @ ..] => {
+                if *size % align_of::<usize>() != 0 {
+                    debug_assert_eq!(*size % align_of::<usize>(), 0);
+                    return None;
+                }
+                let (payload, tail) = tail.split_at_mut(*size / size_of::<usize>());
+                match (*kind).try_into() {
+                    Ok(Kind::End) => {
+                        debug_assert_eq!(*size, 0);
+                        None
+                    }
+                    Ok(Kind::Syscall) => {
+                        debug_assert!(*size >= size_of::<Syscall>());
+                        let data_size = size.checked_sub(size_of::<Syscall>())?;
+
+                        debug_assert_eq!(
+                            size_of::<Syscall>(),
+                            SYSCALL_USIZE_COUNT * size_of::<usize>()
+                        );
+                        let (syscall, data) = payload.split_at_mut(SYSCALL_USIZE_COUNT);
+
+                        let syscall: &mut [usize; SYSCALL_USIZE_COUNT] = syscall.try_into().ok()?;
+                        let (prefix, data, suffix) = unsafe { data.align_to_mut::<u8>() };
+                        if !prefix.is_empty() || !suffix.is_empty() || data.len() != data_size {
+                            debug_assert!(prefix.is_empty());
+                            debug_assert!(suffix.is_empty());
+                            debug_assert_eq!(data.len(), data_size);
+                            return None;
+                        }
+                        Some((Some(Item::Syscall(syscall.into(), data)), tail.into()))
+                    }
+                    Err(_) => Some((None, tail.into())),
+                }
             }
+            _ => None,
         }
     }
 }
 
-/// Reference to untrusted `sallyport` block.
-#[derive(Debug, PartialEq)]
-#[repr(transparent)]
-pub struct Block<'a>(NonNull<[u8]>, PhantomData<&'a ()>);
-
-impl<'a, const N: usize> From<NonNull<[usize; N]>> for Block<'a> {
-    #[inline]
-    fn from(buffer: NonNull<[usize; N]>) -> Self {
-        Self(
-            unsafe {
-                NonNull::new_unchecked(slice_from_raw_parts_mut(
-                    buffer.as_ptr() as _,
-                    N * size_of::<usize>(),
-                ))
-            },
-            PhantomData,
-        )
-    }
-}
-
-impl<'a> IntoIterator for Block<'a> {
-    type Item = Item<'a>;
-    type IntoIter = Iter<'a>;
+impl<'a> Iterator for Block<'a> {
+    type Item = Option<Item<'a>>;
 
     #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        Iter(self.0, PhantomData)
+    fn next(self) -> Option<(Self::Item, Block<'a>)> {
+        self.into()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::read_one;
+
+    #[test]
+    fn syscall_size() {
+        assert_eq!(
+            size_of::<Syscall>(),
+            SYSCALL_USIZE_COUNT * size_of::<usize>()
+        )
+    }
 
     #[test]
     fn block() {
         let mut block: [usize; 25] = [
-            10 * size_of::<usize>(), // size
-            Kind::Syscall as _,      // kind
-            libc::SYS_read as _,     // num
-            1,                       // fd
-            0,                       // buf
-            2,                       // count
-            0,                       // -
-            0,                       // -
-            0,                       // -
-            -libc::ENOSYS as _,      // ret
-            0,                       // -
-            0xdeadbeef,              // data
+            (SYSCALL_USIZE_COUNT + 1) * size_of::<usize>(), // size
+            Kind::Syscall as _,                             // kind
+            libc::SYS_read as _,                            // num
+            1,                                              // fd
+            0,                                              // buf
+            4,                                              // count
+            0,                                              // -
+            0,                                              // -
+            0,                                              // -
+            -libc::ENOSYS as _,                             // ret
+            0,                                              // -
+            0xdeadbeef,                                     // data
             /* --------------------- */
-            9 * size_of::<usize>(), // size
-            Kind::Syscall as _,     // kind
-            libc::SYS_exit as _,    // num
-            5,                      // status
-            0,                      // -
-            0,                      // -
-            0,                      // -
-            0,                      // -
-            0,                      // -
-            -libc::ENOSYS as _,     // ret
-            0,                      // -
+            SYSCALL_USIZE_COUNT * size_of::<usize>(), // size
+            Kind::Syscall as _,                       // kind
+            libc::SYS_exit as _,                      // num
+            5,                                        // status
+            0,                                        // -
+            0,                                        // -
+            0,                                        // -
+            0,                                        // -
+            0,                                        // -
+            -libc::ENOSYS as _,                       // ret
+            0,                                        // -
             /* --------------------- */
             0,              // size
             Kind::End as _, // kind
         ];
-        let items = Block::from(NonNull::from(&mut block))
-            .into_iter()
-            .collect::<Vec<Item>>();
 
-        assert_eq!(items.len(), 2);
-        assert!(matches!(items[0], Item::Syscall { ptr, .. } if {
-            let (Syscall{ num, argv, ret }, data): (_, *mut u32) = unsafe {read_one(ptr.cast())};
-            assert_eq!(SlicePtr::len(ptr.as_ptr() as *const [u8]), size_of::<usize>());
-            assert_eq!(num, libc::SYS_read as _);
-            assert_eq!(argv, [1, 0, 2, 0, 0, 0]);
-            assert_eq!(ret, [-libc::ENOSYS as _, 0]);
-            assert_eq!(unsafe{ data.read() }, 0xdeadbeef);
-            true
-        }));
-        assert!(matches!(items[1], Item::Syscall { ptr, .. } if {
-            let (Syscall{ num, argv, ret }, _): (_, *mut ()) = unsafe {read_one(ptr.cast())};
-            assert_eq!(SlicePtr::len(ptr.as_ptr() as *const [u8]), 0);
-            assert_eq!(num, libc::SYS_exit as _);
-            assert_eq!(argv, [5, 0, 0, 0, 0, 0]);
-            assert_eq!(ret, [-libc::ENOSYS as _, 0]);
-            true
-        }));
+        let (item, tail) = Block::from(&mut block[..]).next().unwrap();
+        assert!(
+            matches!(item, Some(Item::Syscall (Syscall{ num, argv, ret }, data)) if {
+                assert_eq!(*num, libc::SYS_read as _);
+                assert_eq!(*argv, [1, 0, 4, 0, 0, 0]);
+                assert_eq!(*ret, [-libc::ENOSYS as _, 0]);
+                assert_eq!(data, [0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0]);
+                true
+            })
+        );
+
+        let (item, tail) = tail.next().unwrap();
+        assert!(
+            matches!(item, Some(Item::Syscall (Syscall{ num, argv, ret }, data)) if {
+                assert_eq!(*num, libc::SYS_exit as _);
+                assert_eq!(*argv, [5, 0, 0, 0, 0, 0]);
+                assert_eq!(*ret, [-libc::ENOSYS as _, 0]);
+                assert_eq!(data, []);
+                true
+            })
+        );
+        assert!(tail.next().is_none());
     }
 }

--- a/src/v2/src/iter/mod.rs
+++ b/src/v2/src/iter/mod.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Consuming, tail-recursive iterators.
+
+/// An interface for dealing with consuming, tail-recursive iterators.
+///
+/// This is an adaptation of [`core::iter::Iterator`]. For more about the concept of iterators
+/// generally, please see the [core::iter].
+pub trait Iterator: Sized {
+    type Item;
+
+    /// Consumes the iterator and returns a tuple of the next value and iterator tail.
+    ///
+    /// Returns [`None`] when iteration is finished.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use sallyport::iter::Iterator;
+    ///
+    /// let a = [1, 2, 3];
+    ///
+    /// let iter = a.iter();
+    ///
+    /// // A call to next() returns the next value...
+    /// let (item, iter) = Iterator::next(iter).unwrap();
+    /// assert_eq!(&1, item);
+    /// let (item, iter) = iter.next().unwrap();
+    /// assert_eq!(&2, item);
+    /// let (item, iter) = iter.next().unwrap();
+    /// assert_eq!(&3, item);
+    ///
+    /// // ... and then None once it's over.
+    /// assert!(iter.next().is_none());
+    /// ```
+    fn next(self) -> Option<(Self::Item, Self)>;
+
+    #[inline]
+    fn fold<T, F>(self, init: T, mut f: F) -> T
+    where
+        F: FnMut(T, Self::Item) -> T,
+    {
+        let (mut accum, mut tail) = (init, self);
+        while let Some((x, iter)) = tail.next() {
+            accum = f(accum, x);
+            tail = iter;
+        }
+        accum
+    }
+
+    #[inline]
+    fn for_each<F>(self, f: F)
+    where
+        Self: Sized,
+        F: FnMut(Self::Item),
+    {
+        #[inline]
+        fn call<T>(mut f: impl FnMut(T)) -> impl FnMut((), T) {
+            move |(), item| f(item)
+        }
+
+        self.fold((), call(f));
+    }
+}
+
+impl<T: core::iter::Iterator> Iterator for T {
+    type Item = T::Item;
+
+    fn next(mut self) -> Option<(Self::Item, Self)> {
+        T::next(&mut self).map(|item| (item, self))
+    }
+}
+
+pub trait IntoIterator {
+    type Item;
+    type IntoIter: Iterator<Item = Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter;
+}
+
+impl<T: core::iter::IntoIterator> IntoIterator for T {
+    type Item = T::Item;
+    type IntoIter = T::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        T::into_iter(self)
+    }
+}

--- a/src/v2/src/lib.rs
+++ b/src/v2/src/lib.rs
@@ -55,6 +55,7 @@
 
 #![cfg_attr(not(test), no_std)]
 
+pub mod host;
 pub(crate) mod item;
 
 /// Error type used within this crate.

--- a/src/v2/src/lib.rs
+++ b/src/v2/src/lib.rs
@@ -56,7 +56,7 @@
 #![cfg_attr(not(test), no_std)]
 
 pub mod host;
-pub(crate) mod item;
+pub mod item;
 
 /// Error type used within this crate.
 pub type Error = libc::c_int;

--- a/src/v2/src/lib.rs
+++ b/src/v2/src/lib.rs
@@ -58,6 +58,7 @@
 
 pub mod host;
 pub mod item;
+pub mod iter;
 
 /// Error type used within this crate.
 pub type Error = libc::c_int;

--- a/src/v2/src/lib.rs
+++ b/src/v2/src/lib.rs
@@ -19,12 +19,13 @@
 //!
 //! # Block format
 //!
-//! The sallyport block is a region of memory containing zero or more items. All items contain the following header:
+//! The sallyport [block](item::Block) is a region of memory containing zero or more [items](item::Item).
+//! All items contain the following [header](item::Header):
 //!
 //! * size: `usize`
 //! * kind: `usize`
 //!
-//! The size parameter includes the full length of the item except the header value. The contents of the item are defined by the value of the `kind` parameter. An item with an unknown `kind` can be skipped since the length of the item is known from the `size` field. The recipient of an item with an unknown `kind` MUST NOT try to interpret or modify the contents of the item in any way.
+//! The size parameter includes the full length of the item except the header value. The contents of the item are defined by the value of the [`kind`](item::Kind) parameter. An item with an unknown [`kind`](item::Kind) can be skipped since the length of the item is known from the `size` field. The recipient of an item with an unknown [`kind`](item::Kind) MUST NOT try to interpret or modify the contents of the item in any way.
 //!
 //! ## Kinds
 //!
@@ -34,7 +35,7 @@
 //!
 //! ### End
 //!
-//! An `END` item MUST have a `size` of `0`. It has no contents and simply marks the end of items in the block. This communicates the end of the items list to the host. However, the guest MUST NOT rely on the presence of a terminator upon return to the guest.
+//! An [`END`](item::Kind::End) item MUST have a `size` of `0`. It has no contents and simply marks the end of items in the block. This communicates the end of the items list to the host. However, the guest MUST NOT rely on the presence of a terminator upon return to the guest.
 //!
 //! ### Syscall
 //!


### PR DESCRIPTION
Host block executor for enarx/sallyport#17 

Blocked by ~#26~ enarx/sallyport#28 

- Added a custom `Iterator` trait, which supports consuming, tail-recursive implementations
- Added example `exit` call handler.
- Updated the toolchain used by CI to allow using const generics.