### PR TITLE
fix: remove asm feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,6 @@
 //! 1. The shim examines the `Reply` in the `Message` header of the `Block` and propagates any mutated data back to
 //! the protected address space. It may then return control to its workload.
 
-#![cfg_attr(feature = "asm", feature(asm))]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 #![cfg_attr(not(test), no_std)]
@@ -85,6 +84,8 @@ pub mod syscall;
 mod tests;
 pub mod untrusted;
 
+#[cfg(feature = "asm")]
+use core::arch::asm;
 use core::mem::size_of;
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;


### PR DESCRIPTION
`asm` is now stable on nightly.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
