### PR TITLE
Drop support for 1.57.0 and `stable` toolchains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         toolchain:
           - nightly
-          - stable
-          - 1.57.0
         features:
           -
         profile:


### PR DESCRIPTION
Drop support for 1.57.0 and `stable` toolchains