### PR TITLE
Run miri test on CI, test both crate versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         name: cargo test
         with:
           command: test
-          args: ${{ matrix.profile.flag }}
+          args: --manifest-path ${{ matrix.manifest-path }} ${{ matrix.profile.flag }}
       - uses: actions-rs/cargo@v1
         name: cargo miri setup
         with:
@@ -27,7 +27,7 @@ jobs:
           MIRIFLAGS: "-Zmiri-disable-isolation"
         with:
           command: miri
-          args: test
+          args: test --manifest-path ${{ matrix.manifest-path }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,3 +39,6 @@ jobs:
           - name: debug
           - name: release
             flag: --release
+        manifest-path:
+          - Cargo.toml
+          - src/v2/Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,24 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true
+          components: miri, rust-src
       - uses: actions-rs/cargo@v1
+        name: cargo test
         with:
           command: test
           args: ${{ matrix.profile.flag }}
+      - uses: actions-rs/cargo@v1
+        name: cargo miri setup
+        with:
+          command: miri
+          args: setup
+      - uses: actions-rs/cargo@v1
+        name: cargo miri test
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"
+        with:
+          command: miri
+          args: test
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,15 +34,8 @@ jobs:
         toolchain:
           - nightly
         features:
-          -
+          - asm
         profile:
           - name: debug
           - name: release
             flag: --release
-        include:
-          - toolchain: nightly
-            features: asm
-            profile: {name: debug}
-          - toolchain: nightly
-            features: asm
-            profile: {name: release, flag: --release}


### PR DESCRIPTION
- Run `cargo miri test` on CI
- Test both crate versions present in the repo (currently, only v1 tests are run)
- Simplify test matrix
