### PR TITLE
Add support for `sync` syscall

### DIFF
--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -60,6 +60,7 @@ pub trait Execute {
                 let buf = self.platform().validate_slice_mut(buf, count)?;
                 self.read(fd as _, buf).map(|ret| [ret, 0])
             }
+            (libc::SYS_sync, ..) => self.sync().map(|_| [0, 0]),
             (libc::SYS_write, [fd, buf, count, ..]) => {
                 let buf = self.platform().validate_slice(buf, count)?;
                 self.write(fd as _, buf).map(|ret| [ret, 0])
@@ -83,6 +84,11 @@ pub trait Execute {
     fn read(&mut self, fd: c_int, buf: &mut [u8]) -> Result<size_t> {
         self.execute(syscall::Read { fd, buf })?
             .unwrap_or_else(|| self.attacked())
+    }
+
+    /// Executes [`sync`](https://man7.org/linux/man-pages/man2/sync.2.html) syscall akin to [`libc::sync`].
+    fn sync(&mut self) -> Result<()> {
+        self.execute(syscall::Sync)?
     }
 
     /// Executes [`write`](https://man7.org/linux/man-pages/man2/write.2.html) syscall akin to [`libc::write`].

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -10,6 +10,7 @@ mod close;
 mod exit;
 mod read;
 mod result;
+mod sync;
 mod write;
 
 pub use argv::*;
@@ -17,4 +18,5 @@ pub use close::*;
 pub use exit::*;
 pub use read::*;
 pub use result::*;
+pub use sync::*;
 pub use write::*;

--- a/src/v2/src/guest/syscall/sync.rs
+++ b/src/v2/src/guest/syscall/sync.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Argv;
+use crate::guest::alloc::{Allocator, Collector, Syscall};
+use crate::Result;
+
+use libc::c_long;
+
+pub struct Sync;
+
+unsafe impl<'a> Syscall<'a> for Sync {
+    const NUM: c_long = libc::SYS_sync;
+
+    type Argv = Argv<0>;
+    type Ret = super::Result<()>;
+
+    type Staged = ();
+    type Committed = ();
+    type Collected = Result<()>;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        Ok((Argv([]), ()))
+    }
+
+    fn collect(_: Self::Committed, ret: Self::Ret, _: &impl Collector) -> Result<()> {
+        ret.into()
+    }
+}

--- a/src/v2/src/host/mod.rs
+++ b/src/v2/src/host/mod.rs
@@ -70,6 +70,14 @@ mod tests {
             ),
             (
                 Syscall {
+                    num: SYS_sync as _,
+                    argv: [0, 0, 0, 0, 0, 0],
+                    ret: [-ENOSYS as _, 0],
+                },
+                [],
+            ),
+            (
+                Syscall {
                     num: SYS_write as _,
                     argv: [STDOUT_FILENO as _, 0, 0, 0, 0, 0],
                     ret: [-ENOSYS as _, 0],
@@ -87,11 +95,13 @@ mod tests {
         ];
         let (fcntl, tail) = syscalls.split_first_mut().unwrap();
         let (read, tail) = tail.split_first_mut().unwrap();
+        let (sync, tail) = tail.split_first_mut().unwrap();
         let (write, tail) = tail.split_first_mut().unwrap();
         let (close, _) = tail.split_first_mut().unwrap();
         super::execute([
             Item::Syscall(&mut fcntl.0, &mut fcntl.1),
             Item::Syscall(&mut read.0, &mut read.1),
+            Item::Syscall(&mut sync.0, &mut sync.1),
             Item::Syscall(&mut write.0, &mut write.1),
             Item::Syscall(&mut close.0, &mut close.1),
         ]);
@@ -110,6 +120,17 @@ mod tests {
                     Syscall {
                         num: SYS_read as _,
                         argv: [STDIN_FILENO as _, 0, 0, 0, 0, 0],
+                        #[cfg(feature = "asm")]
+                        ret: [0, 0],
+                        #[cfg(not(feature = "asm"))]
+                        ret: [-ENOSYS as _, 0],
+                    },
+                    []
+                ),
+                (
+                    Syscall {
+                        num: SYS_sync as _,
+                        argv: [0, 0, 0, 0, 0, 0],
                         #[cfg(feature = "asm")]
                         ret: [0, 0],
                         #[cfg(not(feature = "asm"))]

--- a/src/v2/src/host/syscall.rs
+++ b/src/v2/src/host/syscall.rs
@@ -166,6 +166,17 @@ pub(super) unsafe fn execute_syscall(syscall: &mut item::Syscall, data: &mut [u8
 
         item::Syscall {
             num,
+            argv: _,
+            ret: [ret, ..],
+        } if *num == libc::SYS_sync as _ => Syscall {
+            num: libc::SYS_sync,
+            argv: [],
+            ret: [ret],
+        }
+        .execute(),
+
+        item::Syscall {
+            num,
             argv: [fd, buf_offset, count, ..],
             ret: [ret, ..],
         } if *num == libc::SYS_write as _ => {

--- a/src/v2/tests/integration_tests.rs
+++ b/src/v2/tests/integration_tests.rs
@@ -9,7 +9,7 @@ use std::os::unix::prelude::AsRawFd;
 use std::ptr::NonNull;
 use std::slice;
 
-use sallyport::guest::{Execute, Handler, Platform};
+use sallyport::guest::{syscall, Execute, Handler, Platform};
 use sallyport::item::Block;
 use sallyport::{host, Result};
 use serial_test::serial;
@@ -81,6 +81,35 @@ fn read() {
             assert_eq!(buf, EXPECTED.as_bytes());
         } else {
             assert_eq!(ret, Err(ENOSYS));
+        }
+    });
+}
+
+#[test]
+#[serial]
+fn sync_read_close() {
+    const EXPECTED: &str = "sync-read-close";
+    let path = temp_dir().join("sallyport-test-sync-read-close");
+    write!(&mut File::create(&path).unwrap(), "{}", EXPECTED).unwrap();
+
+    let c_path = CString::new(path.as_os_str().to_str().unwrap()).unwrap();
+    run_test(3, [0xff; 64], move |handler| {
+        let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY, 0o666) };
+
+        let mut buf = [0u8; EXPECTED.len()];
+        let ret = handler.execute((
+            syscall::Sync,
+            syscall::Read { fd, buf: &mut buf },
+            syscall::Close { fd },
+        ));
+
+        if cfg!(feature = "asm") {
+            assert_eq!(ret, Ok((Ok(()), Some(Ok(EXPECTED.len())), Ok(()))));
+            assert_eq!(buf, EXPECTED.as_bytes());
+            assert_eq!(unsafe { libc::close(fd) }, -1);
+            assert_eq!(unsafe { libc::__errno_location().read() }, libc::EBADF);
+        } else {
+            assert_eq!(ret, Ok((Err(ENOSYS), Some(Err(ENOSYS)), Err(ENOSYS))));
         }
     });
 }


### PR DESCRIPTION
Part of #34 

The tuple trait implementations are used for syscall implementations and, as a side effect, enable batching by design, which is utilized in the test