### PR TITLE
Add support for `{read,write}v` syscalls

### DIFF
--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -387,6 +387,17 @@ pub trait Execute {
         self.execute(syscall::Write { fd, buf })?
             .unwrap_or_else(|| self.attacked())
     }
+
+    /// Executes [`writev`](https://man7.org/linux/man-pages/man2/writev.2.html) syscall by mapping
+    /// it onto a single [`write`](https://man7.org/linux/man-pages/man2/write.2.html).
+    fn writev<T: ?Sized, U>(&mut self, fd: c_int, iovs: &T) -> Result<size_t>
+    where
+        for<'a> &'a T: IntoIterator<Item = &'a U>,
+        U: AsRef<[u8]>,
+    {
+        self.execute(syscall::Writev { fd, iovs })?
+            .unwrap_or_else(|| self.attacked())
+    }
 }
 
 /// Guest request handler.
@@ -657,6 +668,10 @@ impl<'a, P: Platform> Execute for Handler<'a, P> {
             (libc::SYS_write, [fd, buf, count, ..]) => {
                 let buf = self.platform.validate_slice(buf, count)?;
                 self.write(fd as _, buf).map(|ret| [ret, 0])
+            }
+            (libc::SYS_writev, [fd, iov, iovcnt, ..]) => {
+                let iovs = self.platform.validate_iovec_slice(iov, iovcnt)?;
+                self.writev(fd as _, iovs).map(|ret| [ret, 0])
             }
             _ => Err(ENOSYS),
         }

--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -253,6 +253,19 @@ pub trait Execute {
             .unwrap_or_else(|| self.attacked())
     }
 
+    /// Executes [`readv`](https://man7.org/linux/man-pages/man2/readv.2.html) syscall by mapping
+    /// it onto a single [`read`](https://man7.org/linux/man-pages/man2/read.2.html).
+    fn readv<T: ?Sized, U, V>(&mut self, fd: c_int, iovs: &mut T) -> Result<size_t>
+    where
+        for<'a> &'a T: IntoIterator<Item = &'a U>,
+        for<'a> &'a mut T: IntoIterator<Item = &'a mut V>,
+        U: AsRef<[u8]>,
+        V: AsMut<[u8]>,
+    {
+        self.execute(syscall::Readv { fd, iovs })?
+            .unwrap_or_else(|| self.attacked())
+    }
+
     /// Executes [`recv`](https://man7.org/linux/man-pages/man2/recv.2.html) syscall akin to [`libc::recv`].
     fn recv(&mut self, sockfd: c_int, buf: &mut [u8], flags: c_int) -> Result<size_t> {
         self.execute(syscall::Recv { sockfd, buf, flags })?
@@ -556,6 +569,10 @@ impl<'a, P: Platform> Execute for Handler<'a, P> {
                 let pathname = self.platform.validate_str(pathname)?;
                 let buf = self.platform.validate_slice_mut(buf, bufsiz)?;
                 self.readlink(pathname, buf).map(|ret| [ret, 0])
+            }
+            (libc::SYS_readv, [fd, iov, iovcnt, ..]) => {
+                let iovs = self.platform.validate_iovec_slice_mut(iov, iovcnt)?;
+                self.readv(fd as _, iovs).map(|ret| [ret, 0])
             }
             (libc::SYS_recvfrom, [sockfd, buf, len, flags, src_addr, addrlen, ..]) => {
                 let buf = self.platform.validate_slice_mut(buf, len)?;

--- a/src/v2/src/guest/platform.rs
+++ b/src/v2/src/guest/platform.rs
@@ -25,10 +25,26 @@ pub trait Platform {
     fn validate_slice_mut<'a, T>(&self, ptr: usize, len: usize) -> Result<&'a mut [T], c_int>;
 
     /// Validates that a region of memory is valid for read-only access for `len` elements of type `T`.
-    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    /// Returns an immutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
     fn validate_slice<'a, T>(&self, ptr: usize, len: usize) -> Result<&'a [T], c_int> {
         self.validate_slice_mut(ptr, len).map(|v| v as _)
     }
+
+    /// Validates that pointer `iov` points to represents a slice of `iovcnt` pointers to [`libc::iovec`] structures
+    /// valid for read-write access.
+    /// Returns a mutable borrow of the [`libc::iovec`] structs as a 2-dimensional slice
+    /// of mutable byte buffer borrows if valid, otherwise [`EINVAL`](libc::EINVAL).
+    fn validate_iovec_slice_mut<'a>(
+        &self,
+        iov: usize,
+        iovcnt: usize,
+    ) -> Result<&'a mut [&'a mut [u8]], c_int>;
+
+    /// Validates that pointer `iov` points to represents a slice of `iovcnt` pointers to [`libc::iovec`] structures
+    /// valid for read-only access.
+    /// Returns an immutable borrow of the [`libc::iovec`] structs as a 2-dimensional slice
+    /// of immutable byte buffer borrows if valid, otherwise [`EINVAL`](libc::EINVAL).
+    fn validate_iovec_slice<'a>(&self, iov: usize, iovcnt: usize) -> Result<&'a [&'a [u8]], c_int>;
 
     /// Validates that a region of memory represents a C string and is valid for read-only access.
     /// Returns an immutable borrow of bytes of the string without nul terminator byte if valid,

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -28,6 +28,7 @@ mod sendto;
 mod setsockopt;
 mod stub;
 mod write;
+mod writev;
 
 pub mod types;
 
@@ -54,6 +55,7 @@ pub use sendto::*;
 pub use setsockopt::*;
 pub use stub::*;
 pub use write::*;
+pub use writev::Writev;
 
 /// Computes the sum of length of all `iovec` elements in a `iov`.
 pub(super) fn iov_len<'a, T, U>(iter: &'a T) -> usize

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -19,6 +19,7 @@ mod getsockname;
 mod passthrough;
 mod poll;
 mod read;
+mod readv;
 mod recv;
 mod recvfrom;
 mod result;
@@ -44,6 +45,7 @@ pub use getsockname::*;
 pub use passthrough::*;
 pub use poll::*;
 pub use read::*;
+pub use readv::Readv;
 pub use recv::*;
 pub use recvfrom::*;
 pub use result::Result;
@@ -52,3 +54,13 @@ pub use sendto::*;
 pub use setsockopt::*;
 pub use stub::*;
 pub use write::*;
+
+/// Computes the sum of length of all `iovec` elements in a `iov`.
+pub(super) fn iov_len<'a, T, U>(iter: &'a T) -> usize
+where
+    T: ?Sized,
+    &'a T: IntoIterator<Item = U>,
+    U: AsRef<[u8]>,
+{
+    iter.into_iter().map(|iov| iov.as_ref().len()).sum()
+}

--- a/src/v2/src/guest/syscall/readv.rs
+++ b/src/v2/src/guest/syscall/readv.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::iov_len;
+use super::types::Argv;
+use crate::guest::alloc::{Allocator, Collector, CommitPassthrough, OutRef, Syscall};
+use crate::Result;
+
+use libc::{c_int, c_long, size_t};
+
+pub struct Readv<T> {
+    pub fd: c_int,
+    pub iovs: T,
+}
+
+pub struct StagedReadv<'a, T> {
+    buf: OutRef<'a, [u8]>,
+    iovs: T,
+}
+
+impl<T> CommitPassthrough for StagedReadv<'_, T> {}
+
+unsafe impl<'a, T: ?Sized, U, V> Syscall<'a> for Readv<&'a mut T>
+where
+    for<'b> &'b T: IntoIterator<Item = &'b U>,
+    for<'b> &'b mut T: IntoIterator<Item = &'b mut V>,
+    U: AsRef<[u8]>,
+    V: AsMut<[u8]>,
+{
+    const NUM: c_long = libc::SYS_read;
+
+    type Argv = Argv<3>;
+    type Ret = size_t;
+
+    type Staged = StagedReadv<'a, &'a mut T>;
+    type Committed = Self::Staged;
+    type Collected = Option<Result<size_t>>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let buf = alloc.allocate_output_slice_max(iov_len(self.iovs as &T))?;
+        Ok((
+            Argv([self.fd as _, buf.offset(), buf.len()]),
+            StagedReadv {
+                iovs: self.iovs,
+                buf,
+            },
+        ))
+    }
+
+    fn collect(
+        Self::Committed { iovs, buf }: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected {
+        #[inline]
+        fn collect_iovs<'a, T, V>(
+            col: &impl Collector,
+            iovs: &'a mut T,
+            buf: OutRef<'a, [u8]>,
+            mut capacity: usize,
+        ) where
+            for<'b> &'b mut T: IntoIterator<Item = &'b mut V>,
+            T: ?Sized,
+            V: AsMut<[u8]>,
+        {
+            unsafe {
+                buf.copy_to_iter_unchecked(
+                    col,
+                    iovs.into_iter().map_while(|iov| {
+                        if capacity == 0 {
+                            return None;
+                        }
+                        let iov = iov.as_mut();
+                        let len = iov.len();
+                        if len <= capacity {
+                            capacity -= len;
+                            Some(iov)
+                        } else {
+                            let mid = capacity;
+                            capacity = 0;
+                            Some(iov.split_at_mut(mid).0)
+                        }
+                    }),
+                )
+            }
+        }
+
+        match ret {
+            Ok(ret) if ret > buf.len() => None,
+            res @ Ok(ret) => {
+                collect_iovs(col, iovs, buf, ret);
+                Some(res)
+            }
+            err => Some(err),
+        }
+    }
+}

--- a/src/v2/src/guest/syscall/writev.rs
+++ b/src/v2/src/guest/syscall/writev.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::iov_len;
+use super::types::Argv;
+use crate::guest::alloc::{Allocator, Collector, Commit, Committer, InRef, Syscall};
+use crate::Result;
+
+use libc::{c_int, c_long, size_t};
+
+pub struct Writev<T> {
+    pub fd: c_int,
+    pub iovs: T,
+}
+
+pub struct StagedWritev<'a, T> {
+    buf: InRef<'a, [u8]>,
+    iovs: T,
+}
+
+impl<'a, T, U> Commit for StagedWritev<'a, &'a T>
+where
+    T: ?Sized,
+    for<'b> &'b T: IntoIterator<Item = &'b U>,
+    U: AsRef<[u8]>,
+{
+    type Item = size_t;
+
+    fn commit(mut self, com: &impl Committer) -> Self::Item {
+        let mut capacity = self.buf.len();
+        unsafe {
+            self.buf.copy_from_iter_unchecked(
+                com,
+                self.iovs.into_iter().map_while(|iov| {
+                    if capacity == 0 {
+                        return None;
+                    }
+                    let iov = iov.as_ref();
+                    let len = iov.len();
+                    if len <= capacity {
+                        capacity -= len;
+                        Some(iov)
+                    } else {
+                        let mid = capacity;
+                        capacity = 0;
+                        Some(iov.split_at(mid).0)
+                    }
+                }),
+            );
+        }
+        self.buf.len()
+    }
+}
+
+unsafe impl<'a, T, U> Syscall<'a> for Writev<&'a T>
+where
+    T: ?Sized,
+    for<'b> &'b T: IntoIterator<Item = &'b U>,
+    U: AsRef<[u8]>,
+{
+    const NUM: c_long = libc::SYS_write;
+
+    type Argv = Argv<3>;
+    type Ret = size_t;
+
+    type Staged = StagedWritev<'a, &'a T>;
+    type Committed = size_t;
+    type Collected = Option<Result<size_t>>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let buf = alloc.allocate_input_slice_max(iov_len(self.iovs))?;
+        Ok((
+            Argv([self.fd as _, buf.offset(), buf.len()]),
+            StagedWritev {
+                iovs: self.iovs,
+                buf,
+            },
+        ))
+    }
+
+    fn collect(
+        count: Self::Committed,
+        ret: Result<Self::Ret>,
+        _: &impl Collector,
+    ) -> Self::Collected {
+        match ret {
+            Ok(ret) if ret > count => None,
+            res @ Ok(_) => Some(res),
+            err => Some(err),
+        }
+    }
+}


### PR DESCRIPTION
Part of #34 
Closes #50 
Closes #60 

Still TODO:
- [x] ~map "opaque" `readv` from `Handler::syscall` to `syscall::Readv` for now I don't see a simple way to do this, I suggest to open a separate issue to tackle this later as technical debt. #50~