### PR TITLE
Add support for stub `get*id` syscalls

### DIFF
--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -4,7 +4,7 @@ use super::alloc::{phase, Alloc, Allocator, Collect, Commit, Committer};
 use super::{syscall, Call, Platform};
 use crate::{item, Result};
 
-use libc::{c_int, size_t, stat, ENOSYS};
+use libc::{c_int, gid_t, pid_t, size_t, stat, uid_t, ENOSYS};
 
 pub trait Execute {
     type Platform: Platform;
@@ -61,6 +61,11 @@ pub trait Execute {
                 let statbuf = self.platform().validate_mut(statbuf)?;
                 self.fstat(fd as _, statbuf).map(|_| [0, 0])
             }
+            (libc::SYS_getegid, ..) => self.getegid().map(|ret| [ret as _, 0]),
+            (libc::SYS_geteuid, ..) => self.geteuid().map(|ret| [ret as _, 0]),
+            (libc::SYS_getgid, ..) => self.getgid().map(|ret| [ret as _, 0]),
+            (libc::SYS_getpid, ..) => self.getpid().map(|ret| [ret as _, 0]),
+            (libc::SYS_getuid, ..) => self.getuid().map(|ret| [ret as _, 0]),
             (libc::SYS_read, [fd, buf, count, ..]) => {
                 let buf = self.platform().validate_slice_mut(buf, count)?;
                 self.read(fd as _, buf).map(|ret| [ret, 0])
@@ -77,6 +82,31 @@ pub trait Execute {
     /// Executes [`close`](https://man7.org/linux/man-pages/man2/close.2.html) syscall akin to [`libc::close`].
     fn close(&mut self, fd: c_int) -> Result<()> {
         self.execute(syscall::Close { fd })?
+    }
+
+    /// Executes [`getegid`](https://man7.org/linux/man-pages/man2/getegid.2.html) syscall akin to [`libc::getegid`].
+    fn getegid(&mut self) -> Result<gid_t> {
+        self.execute(syscall::Getegid)
+    }
+
+    /// Executes [`geteuid`](https://man7.org/linux/man-pages/man2/geteuid.2.html) syscall akin to [`libc::geteuid`].
+    fn geteuid(&mut self) -> Result<uid_t> {
+        self.execute(syscall::Geteuid)
+    }
+
+    /// Executes [`getgid`](https://man7.org/linux/man-pages/man2/getgid.2.html) syscall akin to [`libc::getgid`].
+    fn getgid(&mut self) -> Result<gid_t> {
+        self.execute(syscall::Getgid)
+    }
+
+    /// Executes [`getpid`](https://man7.org/linux/man-pages/man2/getpid.2.html) syscall akin to [`libc::getpid`].
+    fn getpid(&mut self) -> Result<pid_t> {
+        self.execute(syscall::Getpid)
+    }
+
+    /// Executes [`getuid`](https://man7.org/linux/man-pages/man2/getuid.2.html) syscall akin to [`libc::getuid`].
+    fn getuid(&mut self) -> Result<uid_t> {
+        self.execute(syscall::Getuid)
     }
 
     /// Executes [`exit`](https://man7.org/linux/man-pages/man2/exit.2.html) syscall akin to [`libc::exit`].

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -11,6 +11,7 @@ mod fstat;
 mod passthrough;
 mod read;
 mod result;
+mod stub;
 mod write;
 
 pub use argv::*;
@@ -19,4 +20,5 @@ pub use fstat::*;
 pub use passthrough::*;
 pub use read::*;
 pub use result::Result;
+pub use stub::*;
 pub use write::Write;

--- a/src/v2/src/guest/syscall/stub.rs
+++ b/src/v2/src/guest/syscall/stub.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::guest::alloc::{Allocator, Collect, Collector, CommitPassthrough};
+use crate::guest::Call;
+use crate::Result;
+
+use libc::{gid_t, pid_t, uid_t};
+
+// TODO: Introduce a macro for trait implementations.
+// https://github.com/enarx/sallyport/issues/53
+
+/// Fake GID returned by enarx.
+pub const FAKE_GID: gid_t = 1000;
+
+/// Fake PID returned by enarx.
+pub const FAKE_PID: pid_t = 1000;
+
+/// Fake UID returned by enarx.
+pub const FAKE_UID: uid_t = 1000;
+
+pub struct Getegid;
+
+impl Call<'_> for Getegid {
+    type Staged = Self;
+    type Committed = Self;
+    type Collected = gid_t;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<Self::Staged> {
+        Ok(self)
+    }
+}
+impl CommitPassthrough for Getegid {}
+impl Collect for Getegid {
+    type Item = gid_t;
+
+    fn collect(self, _: &impl Collector) -> Self::Item {
+        FAKE_GID
+    }
+}
+
+pub struct Geteuid;
+
+impl Call<'_> for Geteuid {
+    type Staged = Self;
+    type Committed = Self;
+    type Collected = uid_t;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<Self::Staged> {
+        Ok(self)
+    }
+}
+impl CommitPassthrough for Geteuid {}
+impl Collect for Geteuid {
+    type Item = uid_t;
+
+    fn collect(self, _: &impl Collector) -> Self::Item {
+        FAKE_UID
+    }
+}
+
+pub struct Getgid;
+
+impl Call<'_> for Getgid {
+    type Staged = Self;
+    type Committed = Self;
+    type Collected = gid_t;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<Self::Staged> {
+        Ok(self)
+    }
+}
+impl CommitPassthrough for Getgid {}
+impl Collect for Getgid {
+    type Item = gid_t;
+
+    fn collect(self, _: &impl Collector) -> Self::Item {
+        FAKE_GID
+    }
+}
+
+pub struct Getpid;
+
+impl Call<'_> for Getpid {
+    type Staged = Self;
+    type Committed = Self;
+    type Collected = pid_t;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<Self::Staged> {
+        Ok(self)
+    }
+}
+impl CommitPassthrough for Getpid {}
+impl Collect for Getpid {
+    type Item = pid_t;
+
+    fn collect(self, _: &impl Collector) -> Self::Item {
+        FAKE_PID
+    }
+}
+
+pub struct Getuid;
+
+impl Call<'_> for Getuid {
+    type Staged = Self;
+    type Committed = Self;
+    type Collected = uid_t;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<Self::Staged> {
+        Ok(self)
+    }
+}
+impl CommitPassthrough for Getuid {}
+impl Collect for Getuid {
+    type Item = uid_t;
+
+    fn collect(self, _: &impl Collector) -> Self::Item {
+        FAKE_UID
+    }
+}


### PR DESCRIPTION
Part of enarx/sallyport#34 
~Blocked by enarx/sallyport#20~

Ideally the traits should be implemented via a `stub!` macro, which will be handled in enarx/enarx#1729