### PR TITLE
Improve guest documentation

### DIFF
--- a/src/v2/src/guest/call.rs
+++ b/src/v2/src/guest/call.rs
@@ -3,21 +3,23 @@
 use super::alloc::{Allocator, Collect, Commit};
 use crate::Result;
 
-/// An executable call.
+/// An [executable](super::Execute::execute) call.
 pub trait Call<'a> {
-    /// Opaque [staged value](Stage::Item) value, which returns [`Self::Committed`] when committed via [`Commit::commit`].
+    /// Opaque staged value, which returns [`Self::Committed`] when committed via [`Commit::commit`].
     ///
-    /// This is primarily designed to serve as a container for dynamic data allocated within [`stage`][Self::stage].
+    /// This is designed to serve as a container for data allocated within [`stage`][Self::stage].
     type Staged: Commit<Item = Self::Committed>;
 
-    /// Opaque [committed value](Commit::Item) returned by [`Commit::commit`] called upon [`Self::Staged`], which is, in turn,
-    /// passed to [`Self::collect`] to yield a [`Self::Collected`].
+    /// Opaque [committed value](Commit::Item) returned by [`Commit::commit`] called upon [`Self::Staged`],
+    /// which is, in turn, passed to [`Collect::collect`] to yield a [`Self::Collected`].
     type Committed: Collect<Item = Self::Collected>;
 
-    /// Value call [collects](Collect::Item) as, which corresponds to its [return value](Self::Ret).
+    /// Value call [collects](Collect::Item) as.
+    ///
+    /// For example, a syscall return value.
     type Collected;
 
-    /// Allocate dynamic data, if necessary and return resulting opaque [staged value](Self::Staged) on success.
+    /// Allocate data, if necessary and return resulting opaque [staged value](Self::Staged) on success.
     fn stage(self, alloc: &mut impl Allocator) -> Result<Self::Staged>;
 }
 

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -11,7 +11,7 @@
 //! attempts to [`exit`](`Handler::exit`) immediately and does so in an infinite loop.
 //!
 //! [`Handler`] provides:
-//! - API for execution of an arbitrary call:
+//! - API for execution of an arbitrary [`Call`]:
 //!     - [`execute`](Handler::execute)
 //!
 //! - [`libc`]-like API for syscall execution using safe Rust abstractions where possible, for example:
@@ -27,8 +27,6 @@
 //! In this phase [input references], [output references] and [inout references] are sequentially allocated within the untrusted sallyport block.
 //!
 //! Once this phase is finished, no more allocations can be made within the untrusted sallyport block.
-//!
-//! Entities that can be staged implement the [`Stage`](alloc::Stage) trait.
 //!
 //! ## Commit
 //! In this phase data is written to [input references] and [inout references] allocated in the stage phase.


### PR DESCRIPTION
Refs enarx/enarx#1725 

- Adapt to API changes (`Stage` trait removal, addition of `guest::Call`) from enarx/sallyport#20 
- Add examples for `alloc` syscall traits.

Rendered guest documentation available at https://rvolosatovs.github.io/universe/rust/sallyport/guest/index.html