### PR TITLE
Add support for a few network-related syscalls

### DIFF
--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -80,6 +80,9 @@ pub trait Execute {
                 self.getrandom(buf, flags as _).map(|ret| [ret as _, 0])
             }
             (libc::SYS_getuid, ..) => self.getuid().map(|ret| [ret as _, 0]),
+            (libc::SYS_listen, [sockfd, backlog, ..]) => {
+                self.listen(sockfd as _, backlog as _).map(|_| [0, 0])
+            }
             (libc::SYS_read, [fd, buf, count, ..]) => {
                 let buf = self.platform().validate_slice_mut(buf, count)?;
                 self.read(fd as _, buf).map(|ret| [ret, 0])
@@ -174,6 +177,11 @@ pub trait Execute {
     /// Executes [`fstat`](https://man7.org/linux/man-pages/man2/fstat.2.html) syscall akin to [`libc::fstat`].
     fn fstat(&mut self, fd: c_int, statbuf: &mut stat) -> Result<()> {
         self.execute(syscall::Fstat { fd, statbuf })?
+    }
+
+    /// Executes [`listen`](https://man7.org/linux/man-pages/man2/listen.2.html) syscall akin to [`libc::listen`].
+    fn listen(&mut self, sockfd: c_int, backlog: c_int) -> Result<()> {
+        self.execute(syscall::Listen { sockfd, backlog })?
     }
 
     /// Executes [`read`](https://man7.org/linux/man-pages/man2/read.2.html) syscall akin to [`libc::read`].

--- a/src/v2/src/guest/syscall/bind.rs
+++ b/src/v2/src/guest/syscall/bind.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Argv;
+use crate::guest::alloc::{Allocator, Collector, Input, Syscall};
+use crate::Result;
+
+use libc::{c_int, c_long};
+
+pub struct Bind<'a> {
+    pub sockfd: c_int,
+    pub addr: &'a [u8],
+}
+
+unsafe impl<'a> Syscall<'a> for Bind<'a> {
+    const NUM: c_long = libc::SYS_bind;
+
+    type Argv = Argv<3>;
+    type Ret = ();
+
+    type Staged = Input<'a, [u8], &'a [u8]>;
+    type Committed = ();
+    type Collected = Result<()>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let addr = Input::stage_slice(alloc, self.addr)?;
+        Ok((Argv([self.sockfd as _, addr.offset(), addr.len()]), addr))
+    }
+
+    fn collect(_: Self::Committed, ret: Result<Self::Ret>, _: &impl Collector) -> Self::Collected {
+        ret
+    }
+}

--- a/src/v2/src/guest/syscall/connect.rs
+++ b/src/v2/src/guest/syscall/connect.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Argv;
+use crate::guest::alloc::{Allocator, Collector, Input, Syscall};
+use crate::Result;
+
+use libc::{c_int, c_long};
+
+pub struct Connect<'a> {
+    pub sockfd: c_int,
+    pub addr: &'a [u8],
+}
+
+unsafe impl<'a> Syscall<'a> for Connect<'a> {
+    const NUM: c_long = libc::SYS_connect;
+
+    type Argv = Argv<3>;
+    type Ret = ();
+
+    type Staged = Input<'a, [u8], &'a [u8]>;
+    type Committed = ();
+    type Collected = Result<()>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let addr = Input::stage_slice(alloc, self.addr)?;
+        Ok((Argv([self.sockfd as _, addr.offset(), addr.len()]), addr))
+    }
+
+    fn collect(_: Self::Committed, ret: Result<Self::Ret>, _: &impl Collector) -> Self::Collected {
+        ret
+    }
+}

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -6,6 +6,7 @@
 mod tests;
 
 mod argv;
+mod connect;
 mod fcntl;
 mod fstat;
 mod passthrough;
@@ -16,6 +17,7 @@ mod stub;
 mod write;
 
 pub use argv::*;
+pub use connect::*;
 pub use fcntl::Fcntl;
 pub use fstat::*;
 pub use passthrough::*;

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -6,6 +6,7 @@
 mod tests;
 
 mod argv;
+mod bind;
 mod connect;
 mod fcntl;
 mod fstat;
@@ -17,6 +18,7 @@ mod stub;
 mod write;
 
 pub use argv::*;
+pub use bind::*;
 pub use connect::*;
 pub use fcntl::Fcntl;
 pub use fstat::*;

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -11,6 +11,7 @@ mod fstat;
 mod passthrough;
 mod read;
 mod result;
+mod setsockopt;
 mod stub;
 mod write;
 
@@ -20,5 +21,6 @@ pub use fstat::*;
 pub use passthrough::*;
 pub use read::*;
 pub use result::Result;
+pub use setsockopt::*;
 pub use stub::*;
 pub use write::Write;

--- a/src/v2/src/guest/syscall/passthrough.rs
+++ b/src/v2/src/guest/syscall/passthrough.rs
@@ -98,6 +98,23 @@ unsafe impl PassthroughSyscall for ExitGroup {
     }
 }
 
+pub struct Socket {
+    pub domain: c_int,
+    pub typ: c_int,
+    pub protocol: c_int,
+}
+
+unsafe impl PassthroughSyscall for Socket {
+    const NUM: c_long = libc::SYS_socket;
+
+    type Argv = Argv<3>;
+    type Ret = c_int;
+
+    fn stage(self) -> Self::Argv {
+        Argv([self.domain as _, self.typ as _, self.protocol as _])
+    }
+}
+
 pub struct Sync;
 
 unsafe impl PassthroughSyscall for Sync {

--- a/src/v2/src/guest/syscall/passthrough.rs
+++ b/src/v2/src/guest/syscall/passthrough.rs
@@ -98,6 +98,22 @@ unsafe impl PassthroughSyscall for ExitGroup {
     }
 }
 
+pub struct Listen {
+    pub sockfd: c_int,
+    pub backlog: c_int,
+}
+
+unsafe impl PassthroughSyscall for Listen {
+    const NUM: c_long = libc::SYS_listen;
+
+    type Argv = Argv<2>;
+    type Ret = ();
+
+    fn stage(self) -> Self::Argv {
+        Argv([self.sockfd as _, self.backlog as _])
+    }
+}
+
 pub struct Socket {
     pub domain: c_int,
     pub typ: c_int,

--- a/src/v2/src/guest/syscall/setsockopt.rs
+++ b/src/v2/src/guest/syscall/setsockopt.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Argv;
+use crate::guest::alloc::{Allocator, Collector, Input, Syscall};
+use crate::Result;
+
+use libc::{c_int, c_long};
+
+pub struct Setsockopt<'a> {
+    pub sockfd: c_int,
+    pub level: c_int,
+    pub optname: c_int,
+    pub optval: &'a [u8],
+}
+
+unsafe impl<'a> Syscall<'a> for Setsockopt<'a> {
+    const NUM: c_long = libc::SYS_setsockopt;
+
+    type Argv = Argv<5>;
+    type Ret = c_int;
+
+    type Staged = ();
+    type Committed = ();
+    type Collected = Result<c_int>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let optval = Input::stage_slice(alloc, self.optval)?;
+        Ok((
+            Argv([
+                self.sockfd as _,
+                self.level as _,
+                self.optname as _,
+                optval.offset(),
+                optval.len(),
+            ]),
+            (),
+        ))
+    }
+
+    fn collect(_: Self::Committed, ret: Result<Self::Ret>, _: &impl Collector) -> Self::Collected {
+        ret
+    }
+}

--- a/src/v2/src/host/syscall.rs
+++ b/src/v2/src/host/syscall.rs
@@ -152,6 +152,20 @@ pub(super) unsafe fn execute_syscall(syscall: &mut item::Syscall, data: &mut [u8
 
         item::Syscall {
             num,
+            argv: [sockfd, addr_offset, addrlen, ..],
+            ret: [ret, ..],
+        } if *num == libc::SYS_connect as _ => {
+            let addr = deref::<u8>(data, *addr_offset, *addrlen)?;
+            Syscall {
+                num: libc::SYS_connect,
+                argv: [*sockfd, addr as _, *addrlen],
+                ret: [ret],
+            }
+            .execute()
+        }
+
+        item::Syscall {
+            num,
             argv: [oldfd, ..],
             ret: [ret, ..],
         } if *num == libc::SYS_dup as _ => Syscall {

--- a/src/v2/src/host/syscall.rs
+++ b/src/v2/src/host/syscall.rs
@@ -205,6 +205,17 @@ pub(super) unsafe fn execute_syscall(syscall: &mut item::Syscall, data: &mut [u8
 
         item::Syscall {
             num,
+            argv: [sockfd, backlog, ..],
+            ret: [ret, ..],
+        } if *num == libc::SYS_listen as _ => Syscall {
+            num: libc::SYS_listen,
+            argv: [*sockfd, *backlog],
+            ret: [ret],
+        }
+        .execute(),
+
+        item::Syscall {
+            num,
             argv: [fd, buf_offset, count, ..],
             ret: [ret, ..],
         } if *num == libc::SYS_read as _ => {

--- a/src/v2/src/host/syscall.rs
+++ b/src/v2/src/host/syscall.rs
@@ -221,6 +221,17 @@ pub(super) unsafe fn execute_syscall(syscall: &mut item::Syscall, data: &mut [u8
 
         item::Syscall {
             num,
+            argv: [domain, typ, protocol, ..],
+            ret: [ret, ..],
+        } if *num == libc::SYS_socket as _ => Syscall {
+            num: libc::SYS_socket,
+            argv: [*domain, *typ, *protocol],
+            ret: [ret],
+        }
+        .execute(),
+
+        item::Syscall {
+            num,
             argv: _,
             ret: [ret, ..],
         } if *num == libc::SYS_sync as _ => Syscall {

--- a/src/v2/src/host/syscall.rs
+++ b/src/v2/src/host/syscall.rs
@@ -141,6 +141,20 @@ pub(super) unsafe fn execute_syscall(syscall: &mut item::Syscall, data: &mut [u8
     match syscall {
         item::Syscall {
             num,
+            argv: [sockfd, addr_offset, addrlen, ..],
+            ret: [ret, ..],
+        } if *num == libc::SYS_bind as _ => {
+            let addr = deref::<u8>(data, *addr_offset, *addrlen)?;
+            Syscall {
+                num: libc::SYS_bind,
+                argv: [*sockfd, addr as _, *addrlen],
+                ret: [ret],
+            }
+            .execute()
+        }
+
+        item::Syscall {
+            num,
             argv: [fd, ..],
             ret: [ret, ..],
         } if *num == libc::SYS_close as _ => Syscall {


### PR DESCRIPTION
Part of enarx/sallyport#34 

~Ideally, we should use `deref` utility from enarx/sallyport#47 here on the host side, that should be handled in whichever PR gets merged first.~ I extracted it from enarx/sallyport#47 here due to CI issues

No tests to speed up development, although the syscalls are pretty trivial - ~I will file a follow-up issue about it~ enarx/enarx#1730