### PR TITLE
Add support for `clock_gettime`

### DIFF
--- a/src/v2/src/guest/syscall/clock_gettime.rs
+++ b/src/v2/src/guest/syscall/clock_gettime.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Argv;
+use crate::guest::alloc::{Allocator, Collect, Collector, Output, Syscall};
+use crate::Result;
+
+use libc::{c_long, clockid_t, timespec};
+
+pub struct ClockGettime<'a> {
+    pub clockid: clockid_t,
+    pub tp: &'a mut timespec,
+}
+
+unsafe impl<'a> Syscall<'a> for ClockGettime<'a> {
+    const NUM: c_long = libc::SYS_clock_gettime;
+
+    type Argv = Argv<2>;
+    type Ret = ();
+
+    type Staged = Output<'a, timespec, &'a mut timespec>;
+    type Committed = Self::Staged;
+    type Collected = Result<()>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let tp = Output::stage(alloc, self.tp)?;
+        Ok((Argv([self.clockid as _, tp.offset()]), tp))
+    }
+
+    fn collect(
+        tp: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected {
+        if let Ok(_) = ret {
+            tp.collect(col);
+        };
+        ret
+    }
+}

--- a/src/v2/src/guest/syscall/mod.rs
+++ b/src/v2/src/guest/syscall/mod.rs
@@ -7,6 +7,7 @@ mod tests;
 
 mod argv;
 mod bind;
+mod clock_gettime;
 mod connect;
 mod fcntl;
 mod fstat;
@@ -19,6 +20,7 @@ mod write;
 
 pub use argv::*;
 pub use bind::*;
+pub use clock_gettime::*;
 pub use connect::*;
 pub use fcntl::Fcntl;
 pub use fstat::*;


### PR DESCRIPTION
Part of enarx/sallyport#34 

Eventually, this syscall will be "smuggled" in `execute` enarx/enarx#1727

Tests will be added in enarx/enarx#1730 for speed of development