### PR TITLE
Guest allocator `inout` support and a few minor fixes/improvements

### DIFF
--- a/src/v2/Cargo.toml
+++ b/src/v2/Cargo.toml
@@ -29,3 +29,4 @@ libc = { version = "0.2", features = [] }
 
 [dev-dependencies]
 serial_test = "0.5"
+libc = { version = "0.2", features = [ "extra_traits" ] }

--- a/src/v2/src/guest/alloc/inout.rs
+++ b/src/v2/src/guest/alloc/inout.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Commit, Committer, InRef, OutRef};
+use super::{Allocator, Commit, Committer, InRef, OutRef, Output};
+use crate::Result;
 
+use core::borrow::BorrowMut;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
@@ -27,6 +29,13 @@ impl<'a, T: ?Sized> InOutRef<'a, T> {
     }
 }
 
+impl<'a, T: ?Sized> From<InOutRef<'a, T>> for OutRef<'a, T> {
+    #[inline]
+    fn from(r: InOutRef<'a, T>) -> Self {
+        Self::new(r.ptr, r.offset)
+    }
+}
+
 impl<'a, T: ?Sized> Deref for InOutRef<'a, T> {
     type Target = InRef<'a, T>;
 
@@ -48,6 +57,113 @@ impl<'a, T: ?Sized> Commit for InOutRef<'a, T> {
 
     #[inline]
     fn commit(self, _: &impl Committer) -> Self::Item {
-        Self::Item::new(self.0.ptr, self.0.offset)
+        self.into()
+    }
+}
+
+/// Allocated inout.
+pub struct InOut<'a, T: ?Sized, U> {
+    data_ref: InOutRef<'a, T>,
+    val: U,
+}
+
+impl<T: ?Sized, U> InOut<'_, T, U> {
+    /// Returns the byte offset within block.
+    #[inline]
+    pub fn offset(&self) -> usize {
+        self.data_ref.offset()
+    }
+}
+
+impl<T, U> InOut<'_, [T], U> {
+    /// Returns the number of allocated elements of type `T`.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data_ref.len()
+    }
+}
+
+impl<'a, T: ?Sized, U> From<InOut<'a, T, U>> for Output<'a, T, U> {
+    #[inline]
+    fn from(r: InOut<'a, T, U>) -> Self {
+        Self {
+            data_ref: r.data_ref.into(),
+            val: r.val,
+        }
+    }
+}
+
+impl<'a, T> InOutRef<'a, T> {
+    #[inline]
+    pub fn stage<U: BorrowMut<T>>(self, val: U) -> InOut<'a, T, U> {
+        InOut {
+            data_ref: self,
+            val,
+        }
+    }
+}
+
+impl<'a, T> InOutRef<'a, [T]> {
+    #[inline]
+    pub fn stage_slice<U: AsMut<[T]>>(self, val: U) -> InOut<'a, [T], U> {
+        InOut {
+            data_ref: self,
+            val,
+        }
+    }
+}
+
+impl<'a, T, U: BorrowMut<T>> InOut<'a, T, U> {
+    /// Attempts to allocate inout segment to fit `val` in the block
+    /// and returns the resulting [`InOut`] on success.
+    #[inline]
+    pub fn stage(alloc: &mut impl Allocator, val: U) -> Result<Self> {
+        alloc
+            .allocate_inout()
+            .map(move |data_ref| data_ref.stage(val))
+    }
+}
+
+impl<'a, T, U: AsMut<[T]>> InOut<'a, [T], U> {
+    /// Attempts to allocate inout segment to fit `val.len()` elements of `val` in the block
+    /// and returns the resulting [`InOut`] on success.
+    #[inline]
+    pub fn stage_slice(alloc: &mut impl Allocator, mut val: U) -> Result<Self> {
+        alloc
+            .allocate_inout_slice(val.as_mut().len())
+            .map(move |data_ref| data_ref.stage_slice(val))
+    }
+}
+
+impl<'a, T> InOut<'a, [T], &'a mut [T]> {
+    /// Attempts to allocate inout segment to fit as many elements of `val` in the block as capacity allows
+    /// and returns the resulting [`InOut`] on success.
+    #[inline]
+    pub fn stage_slice_max(
+        alloc: &mut impl Allocator,
+        val: &'a mut [T],
+    ) -> Result<(Self, &'a mut [T])> {
+        let (head, tail) = val.split_at_mut(val.len().min(alloc.free::<T>()));
+        Self::stage_slice(alloc, head).map(|input| (input, tail))
+    }
+}
+
+impl<'a, T: Copy, U: BorrowMut<T>> Commit for InOut<'a, T, U> {
+    type Item = Output<'a, T, U>;
+
+    #[inline]
+    fn commit(mut self, com: &impl Committer) -> Self::Item {
+        self.data_ref.copy_from(com, self.val.borrow_mut());
+        self.into()
+    }
+}
+
+impl<'a, T: ?Sized + Copy, U: AsMut<[T]>> Commit for InOut<'a, [T], U> {
+    type Item = Output<'a, [T], U>;
+
+    #[inline]
+    fn commit(mut self, com: &impl Committer) -> Self::Item {
+        unsafe { self.data_ref.copy_from_unchecked(com, self.val.as_mut()) };
+        self.into()
     }
 }

--- a/src/v2/src/guest/alloc/input.rs
+++ b/src/v2/src/guest/alloc/input.rs
@@ -7,7 +7,6 @@ use core::borrow::{Borrow, BorrowMut};
 use core::iter::once;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
-use libc::ENOMEM;
 
 /// Reference to an allocated input segment.
 #[derive(Debug, PartialEq)]
@@ -181,9 +180,6 @@ impl<'a, T> Input<'a, [T], &'a [T]> {
     #[inline]
     pub fn stage_slice_max(alloc: &mut impl Allocator, val: &'a [T]) -> Result<(Self, &'a [T])> {
         let (head, tail) = val.split_at(val.len().min(alloc.free::<T>()));
-        if head.is_empty() {
-            return Err(ENOMEM);
-        }
         Self::stage_slice(alloc, head).map(|input| (input, tail))
     }
 }

--- a/src/v2/src/guest/alloc/mod.rs
+++ b/src/v2/src/guest/alloc/mod.rs
@@ -23,7 +23,6 @@ pub(super) use phase_alloc::*;
 use crate::Result;
 
 use core::alloc::Layout;
-use libc::ENOMEM;
 
 /// Returns a [`Layout`] corresponding to an array of `len` elements of type `T`.
 #[inline]
@@ -152,11 +151,7 @@ pub trait Allocator {
     /// and returns corresponding [`InRef`] on success.
     #[inline]
     fn allocate_input_slice_max<'a, T>(&mut self, len: usize) -> Result<InRef<'a, [T]>> {
-        let len = len.min(self.free::<T>());
-        if len == 0 {
-            return Err(ENOMEM);
-        }
-        self.allocate_input_slice(len)
+        self.allocate_input_slice(len.min(self.free::<T>()))
     }
 
     /// Attempts to allocate a slice output of `len` elements of type `T`
@@ -171,11 +166,7 @@ pub trait Allocator {
     /// and returns corresponding [`OutRef`] on success.
     #[inline]
     fn allocate_output_slice_max<'a, T>(&mut self, len: usize) -> Result<OutRef<'a, [T]>> {
-        let len = len.min(self.free::<T>());
-        if len == 0 {
-            return Err(ENOMEM);
-        }
-        self.allocate_output_slice(len)
+        self.allocate_output_slice(len.min(self.free::<T>()))
     }
 
     /// Attempts to allocate a slice inout of `len` elements of type `T`
@@ -190,11 +181,7 @@ pub trait Allocator {
     /// and returns corresponding [`InOutRef`] on success.
     #[inline]
     fn allocate_inout_slice_max<'a, T>(&mut self, len: usize) -> Result<InOutRef<'a, [T]>> {
-        let len = len.min(self.free::<T>());
-        if len == 0 {
-            return Err(ENOMEM);
-        }
-        self.allocate_inout_slice(len)
+        self.allocate_inout_slice(len.min(self.free::<T>()))
     }
 
     /// Records the end of stage phase and moves allocator into commit phase.

--- a/src/v2/src/guest/alloc/output.rs
+++ b/src/v2/src/guest/alloc/output.rs
@@ -142,13 +142,13 @@ impl<'a, T, U: BorrowMut<T>> Output<'a, T, U> {
     }
 }
 
-impl<'a, T, U: AsRef<[T]>> Output<'a, [T], U> {
+impl<'a, T, U: AsMut<[T]>> Output<'a, [T], U> {
     /// Attempts to allocate input segment to fit `val.len()` elements of `val` in the block
     /// and returns the resulting [`Output`] on success.
     #[inline]
-    pub fn stage_slice(alloc: &mut impl Allocator, val: U) -> Result<Self> {
+    pub fn stage_slice(alloc: &mut impl Allocator, mut val: U) -> Result<Self> {
         alloc
-            .allocate_output_slice(val.as_ref().len())
+            .allocate_output_slice(val.as_mut().len())
             .map(move |data_ref| Output { data_ref, val })
     }
 }

--- a/src/v2/src/guest/alloc/output.rs
+++ b/src/v2/src/guest/alloc/output.rs
@@ -8,7 +8,6 @@ use core::iter::once;
 use core::marker::PhantomData;
 use core::ops::Range;
 use core::ptr::NonNull;
-use libc::ENOMEM;
 
 /// Reference to an allocated output segment.
 #[derive(Debug, PartialEq)]
@@ -163,9 +162,6 @@ impl<'a, T> Output<'a, [T], &'a mut [T]> {
         val: &'a mut [T],
     ) -> Result<(Self, &'a mut [T])> {
         let (head, tail) = val.split_at_mut(val.len().min(alloc.free::<T>()));
-        if head.is_empty() {
-            return Err(ENOMEM);
-        }
         Self::stage_slice(alloc, head).map(|output| (output, tail))
     }
 }

--- a/src/v2/src/guest/alloc/phase_alloc.rs
+++ b/src/v2/src/guest/alloc/phase_alloc.rs
@@ -64,7 +64,7 @@ impl<'a> Alloc<'a, phase::Init> {
     pub fn stage(&mut self) -> Alloc<'a, phase::Stage> {
         Alloc {
             ptr: self.ptr,
-            offset: 0,
+            offset: self.offset,
 
             phase: PhantomData,
         }

--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -65,7 +65,7 @@ pub trait Execute {
         })?
     }
 
-    /// Executes [`eventfd2`](https://man7.org/linux/man-pages/man2/eventfd2.2.html) syscall akin to [`libc::eventfd2`].
+    /// Executes [`eventfd2`](https://man7.org/linux/man-pages/man2/eventfd2.2.html).
     fn eventfd2(&mut self, initval: c_int, flags: c_int) -> Result<c_int> {
         self.execute(syscall::Eventfd2 { initval, flags })?
     }
@@ -76,7 +76,7 @@ pub trait Execute {
         self.attacked()
     }
 
-    /// Executes [`exit_group`](https://man7.org/linux/man-pages/man2/exit_group.2.html) syscall akin to [`libc::exit_group`].
+    /// Executes [`exit_group`](https://man7.org/linux/man-pages/man2/exit_group.2.html).
     fn exit_group(&mut self, status: c_int) -> Result<()> {
         self.execute(syscall::ExitGroup { status })??;
         self.attacked()


### PR DESCRIPTION
#47 sans the actual syscall, for which NULL handling is still to be discussed
blocking #67 #47 (since the dependencies of the implementation are now extracted here)