### PR TITLE
Add GDB call support

### DIFF
--- a/src/v2/Cargo.toml
+++ b/src/v2/Cargo.toml
@@ -22,7 +22,11 @@ is-it-maintained-open-issues = { repository = "enarx/sallyport" }
 
 [dependencies]
 libc = { version = "0.2", features = [] }
+gdbstub = { version = "0.6.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serial_test = "0.5"
 libc = { version = "0.2", features = [ "extra_traits" ] }
+
+[features]
+doc = [ "gdbstub" ]

--- a/src/v2/src/guest/call/alloc.rs
+++ b/src/v2/src/guest/call/alloc.rs
@@ -26,6 +26,12 @@ pub(crate) mod kind {
     }
 
     #[repr(transparent)]
+    pub struct Gdbcall;
+    impl Kind for Gdbcall {
+        const ITEM: item::Kind = item::Kind::Gdbcall;
+    }
+
+    #[repr(transparent)]
     pub struct MaybeAlloc<'a, K: Kind, T: Alloc<'a, K>>(&'a PhantomData<(K, T)>);
     impl<'a, K: Kind, T: Alloc<'a, K>> Kind for MaybeAlloc<'a, K, T> {
         const ITEM: item::Kind = K::ITEM;

--- a/src/v2/src/guest/call/gdbcall/alloc.rs
+++ b/src/v2/src/guest/call/gdbcall/alloc.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::alloc;
+use super::types::{self, CommittedAlloc, StagedAlloc};
+use crate::guest::alloc::{Allocator, Collector, Commit};
+use crate::item::gdbcall::Number;
+use crate::Result;
+
+/// A generic GDB call, which can be allocated within the block.
+///
+/// # Examples
+///
+/// ```rust
+/// use sallyport::item::gdbcall::Number;
+/// use sallyport::guest::alloc::{Allocator, Collector, Input};
+/// use sallyport::guest::call::types::Argv;
+/// use sallyport::guest::gdbcall::Alloc;
+/// use sallyport::guest::gdbcall::types::{StagedBytesInput};
+/// use sallyport::Result;
+///
+/// pub struct WriteAll<'a> {
+///     pub buf: &'a [u8],
+/// }
+///
+/// impl<'a> Alloc<'a> for WriteAll<'a> {
+///     const NUM: Number = Number::WriteAll;
+///
+///     type Argv = Argv<2>;
+///     type Ret = usize;
+///
+///     type Staged = StagedBytesInput<'a>;
+///     type Committed = usize;
+///     type Collected = Option<Result<usize>>;
+///
+///     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+///         let (buf, _) = Input::stage_slice_max(alloc, self.buf)?;
+///         Ok((Argv([buf.offset(), buf.len()]), StagedBytesInput(buf)))
+///     }
+///
+///     fn collect(
+///         count: Self::Committed,
+///         ret: Result<Self::Ret>,
+///         _: &impl Collector,
+///     ) -> Self::Collected {
+///         match ret {
+///             Ok(ret) if ret > count => None,
+///             res @ Ok(_) => Some(res),
+///             err => Some(err),
+///         }
+///     }
+/// }
+/// ```
+pub trait Alloc<'a> {
+    /// GDB call number.
+    ///
+    /// For example, [`item::gdbcall::Number::WriteAll`](Number::WriteAll).
+    const NUM: Number;
+
+    /// The GDB call argument vector.
+    ///
+    /// For example, [`guest::call::types::Argv<2>`](super::super::types::Argv<2>).
+    type Argv: Into<[usize; 4]>;
+
+    /// GDB call return value.
+    ///
+    /// For example, [`usize`].
+    type Ret;
+
+    /// Opaque staged value, which returns [`Self::Committed`] when committed via [`Commit::commit`].
+    ///
+    /// This is designed to serve as a container for dynamic data allocated within [`stage`][Self::stage].
+    ///
+    /// For example, [`Input<'a, [u8], &'a [u8]>`](crate::guest::alloc::Input).
+    type Staged: Commit<Item = Self::Committed>;
+
+    /// Opaque [committed value](crate::guest::alloc::Commit::Item)
+    /// returned by [`guest::alloc::Commit::commit`](crate::guest::alloc::Commit::commit)
+    /// called upon [`Self::Staged`], which returns [`Self::Collected`] when
+    /// collected via [`guest::alloc::Collect::collect`](crate::guest::alloc::Collect::collect).
+    type Committed;
+
+    /// Value GDB call [collects](crate::guest::alloc::Collect::Item) as, which corresponds to its [return value](Self::Ret).
+    ///
+    /// For example, [`Option<Result<usize>>`].
+    type Collected;
+
+    /// Allocate dynamic data, if necessary and return resulting argument vector registers
+    /// and opaque [staged value](Self::Staged) on success.
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)>;
+
+    /// Collect the return registers, [opaque committed value](Self::Committed)
+    /// and return a [`Self::Collected`].
+    fn collect(
+        committed: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected;
+}
+
+impl<'a, T: Alloc<'a>> super::super::Alloc<'a, alloc::kind::Gdbcall> for T
+where
+    types::Result<T::Ret>: Into<Result<T::Ret>>,
+{
+    type Staged = StagedAlloc<'a, T>;
+    type Committed = CommittedAlloc<'a, T>;
+    type Collected = T::Collected;
+
+    #[inline]
+    fn stage(self, alloc: &mut impl Allocator) -> Result<Self::Staged> {
+        let num_ref = alloc.allocate_input()?;
+        let argv_ref = alloc.allocate_input()?;
+        let ret_ref = alloc.allocate_inout()?;
+        let ((argv, staged), _) = alloc.section(|alloc| self.stage(alloc))?;
+        Ok(Self::Staged {
+            num_ref,
+            argv: argv_ref.stage(argv.into()),
+            ret_ref,
+            staged,
+        })
+    }
+}

--- a/src/v2/src/guest/call/gdbcall/mod.rs
+++ b/src/v2/src/guest/call/gdbcall/mod.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! GDB call-specific functionality.
+
+mod alloc;
+mod passthrough;
+mod write_all;
+
+pub mod types;
+
+pub use alloc::*;
+pub use passthrough::*;
+pub use write_all::*;

--- a/src/v2/src/guest/call/gdbcall/passthrough.rs
+++ b/src/v2/src/guest/call/gdbcall/passthrough.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::types::Argv;
+use super::Alloc;
+use crate::guest::alloc::{Allocator, Collector};
+use crate::item::gdbcall::Number;
+use crate::Result;
+
+/// Trait implemented by allocatable GDB calls, which are passed through directly to the host and do
+/// not require custom handling logic.
+///
+/// # Example
+/// ```rust
+/// use sallyport::item::gdbcall::Number;
+/// use sallyport::guest::call::types::Argv;
+/// use sallyport::guest::gdbcall::PassthroughAlloc;
+/// use sallyport::Result;
+///
+/// pub struct Read;
+///
+/// impl PassthroughAlloc for Read {
+///     const NUM: Number = Number::Read;
+///
+///     type Argv = Argv<0>;
+///     type Ret = u8;
+///
+///     fn stage(self) -> Self::Argv {
+///         Argv([])
+///     }
+/// }
+/// ```
+pub trait PassthroughAlloc {
+    /// GDB call number.
+    ///
+    /// For example, [`Number::Read`].
+    const NUM: Number;
+
+    /// The gdbcall argument vector.
+    ///
+    /// For example, [`call::types::Argv<0>`](crate::guest::call::types::Argv<0>).
+    type Argv: Into<[usize; 4]>;
+
+    /// Gdbcall return value.
+    ///
+    /// For example, `u8`.
+    type Ret;
+
+    /// Returns argument vector registers.
+    fn stage(self) -> Self::Argv;
+}
+
+impl<'a, T: PassthroughAlloc> Alloc<'a> for T {
+    const NUM: Number = T::NUM;
+
+    type Argv = T::Argv;
+    type Ret = T::Ret;
+
+    type Staged = ();
+    type Committed = ();
+    type Collected = Result<T::Ret>;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        Ok((T::stage(self), ()))
+    }
+
+    fn collect(_: Self::Committed, ret: Result<Self::Ret>, _: &impl Collector) -> Self::Collected {
+        ret
+    }
+}
+
+#[cfg_attr(feature = "doc", doc = "[`gdbstub::conn::Connection::flush`] call")]
+#[repr(transparent)]
+pub struct Flush;
+
+impl PassthroughAlloc for Flush {
+    const NUM: Number = Number::Flush;
+
+    type Argv = Argv<0>;
+    type Ret = ();
+
+    fn stage(self) -> Self::Argv {
+        Argv([])
+    }
+}
+
+#[cfg_attr(
+    feature = "doc",
+    doc = "[`gdbstub::conn::Connection::on_session_start`] call"
+)]
+#[repr(transparent)]
+pub struct OnSessionStart;
+
+impl PassthroughAlloc for OnSessionStart {
+    const NUM: Number = Number::OnSessionStart;
+
+    type Argv = Argv<0>;
+    type Ret = ();
+
+    fn stage(self) -> Self::Argv {
+        Argv([])
+    }
+}
+
+#[cfg_attr(feature = "doc", doc = "[`gdbstub::conn::ConnectionExt::peek`] call")]
+#[repr(transparent)]
+pub struct Peek;
+
+impl PassthroughAlloc for Peek {
+    const NUM: Number = Number::Peek;
+
+    type Argv = Argv<0>;
+    type Ret = Option<u8>;
+
+    fn stage(self) -> Self::Argv {
+        Argv([])
+    }
+}
+
+#[cfg_attr(feature = "doc", doc = "[`gdbstub::conn::ConnectionExt::read`] call")]
+#[repr(transparent)]
+pub struct Read;
+
+impl PassthroughAlloc for Read {
+    const NUM: Number = Number::Read;
+
+    type Argv = Argv<0>;
+    type Ret = u8;
+
+    fn stage(self) -> Self::Argv {
+        Argv([])
+    }
+}
+
+#[cfg_attr(feature = "doc", doc = "[`gdbstub::conn::Connection::write`] call")]
+#[repr(transparent)]
+pub struct Write {
+    pub byte: u8,
+}
+
+impl PassthroughAlloc for Write {
+    const NUM: Number = Number::Write;
+
+    type Argv = Argv<1>;
+    type Ret = ();
+
+    fn stage(self) -> Self::Argv {
+        Argv([self.byte as _])
+    }
+}

--- a/src/v2/src/guest/call/gdbcall/types/alloc.rs
+++ b/src/v2/src/guest/call/gdbcall/types/alloc.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::Alloc;
+use crate::guest::alloc::{Collect, Collector, Commit, Committer, InOutRef, InRef, Input, OutRef};
+use crate::Result;
+
+/// Staged GDB call, which holds allocated reference to GDB call item within the block and [opaque staged value](Alloc::Staged).
+pub struct StagedAlloc<'a, T: Alloc<'a>> {
+    pub(crate) num_ref: InRef<'a, usize>,
+    pub(crate) argv: Input<'a, [usize; 4], [usize; 4]>,
+    pub(crate) ret_ref: InOutRef<'a, usize>,
+    pub(crate) staged: T::Staged,
+}
+
+impl<'a, T: Alloc<'a>> Commit for StagedAlloc<'a, T> {
+    type Item = CommittedAlloc<'a, T>;
+
+    #[inline]
+    fn commit(mut self, com: &impl Committer) -> Self::Item {
+        self.num_ref.copy_from(com, T::NUM as usize);
+        self.argv.commit(com);
+        self.ret_ref.copy_from(com, -libc::ENOSYS as usize);
+        Self::Item {
+            ret_ref: self.ret_ref.commit(com),
+            committed: self.staged.commit(com),
+        }
+    }
+}
+
+/// Committed GDB call, which holds allocated reference to GDB call return values within the block and [opaque committed value](Alloc::Committed).
+pub struct CommittedAlloc<'a, T: Alloc<'a>> {
+    pub(crate) ret_ref: OutRef<'a, usize>,
+    pub(crate) committed: T::Committed,
+}
+
+impl<'a, T: Alloc<'a>> Collect for CommittedAlloc<'a, T>
+where
+    super::Result<T::Ret>: Into<Result<T::Ret>>,
+{
+    type Item = T::Collected;
+
+    #[inline]
+    fn collect(self, col: &impl Collector) -> Self::Item {
+        let mut ret = 0usize;
+        self.ret_ref.copy_to(col, &mut ret);
+        let res: super::Result<T::Ret> = ret.into();
+        T::collect(self.committed, res.into(), col)
+    }
+}

--- a/src/v2/src/guest/call/gdbcall/types/bytes.rs
+++ b/src/v2/src/guest/call/gdbcall/types/bytes.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::guest::alloc::{Commit, Committer, Input};
+
+#[repr(transparent)]
+pub struct StagedBytesInput<'a>(pub Input<'a, [u8], &'a [u8]>);
+
+impl<'a> Commit for StagedBytesInput<'a> {
+    type Item = usize;
+
+    #[inline]
+    fn commit(self, com: &impl Committer) -> Self::Item {
+        let len = self.0.len();
+        self.0.commit(com);
+        len
+    }
+}

--- a/src/v2/src/guest/call/gdbcall/types/mod.rs
+++ b/src/v2/src/guest/call/gdbcall/types/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Gdbcall-specific types.
+
+mod alloc;
+mod bytes;
+mod result;
+
+pub use alloc::*;
+pub use bytes::*;
+pub use result::*;

--- a/src/v2/src/guest/call/gdbcall/types/result.rs
+++ b/src/v2/src/guest/call/gdbcall/types/result.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::marker::PhantomData;
+use libc::{c_int, EOVERFLOW};
+
+use crate::NULL;
+
+pub const MAX_ERRNO: c_int = 4096;
+pub const ERRNO_START: usize = usize::MAX - MAX_ERRNO as usize;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Result<T>(usize, PhantomData<T>);
+
+impl<T> From<Result<T>> for usize {
+    #[inline]
+    fn from(res: Result<T>) -> Self {
+        res.0
+    }
+}
+
+impl<T> From<usize> for Result<T> {
+    #[inline]
+    fn from(ret: usize) -> Self {
+        Self(ret, PhantomData)
+    }
+}
+
+impl From<Result<()>> for crate::Result<()> {
+    #[inline]
+    fn from(res: Result<()>) -> Self {
+        match res.0 {
+            errno @ ERRNO_START..=usize::MAX => Err(-(errno as c_int)),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl From<Result<usize>> for crate::Result<usize> {
+    #[inline]
+    fn from(res: Result<usize>) -> Self {
+        match res.0 {
+            errno @ ERRNO_START..=usize::MAX => Err(-(errno as c_int)),
+            ret => Ok(ret),
+        }
+    }
+}
+
+impl From<Result<u8>> for crate::Result<u8> {
+    #[inline]
+    fn from(res: Result<u8>) -> Self {
+        match res.0 {
+            errno @ ERRNO_START..=usize::MAX => Err(-(errno as c_int)),
+            ret if ret <= u8::MAX as _ => Ok(ret as _),
+            _ => Err(EOVERFLOW),
+        }
+    }
+}
+
+impl From<Result<Option<u8>>> for crate::Result<Option<u8>> {
+    #[inline]
+    fn from(res: Result<Option<u8>>) -> Self {
+        match res.0 {
+            NULL => Ok(None),
+            ret if ret >= ERRNO_START => Err(-(ret as c_int)),
+            ret if ret <= u8::MAX as _ => Ok(Some(ret as _)),
+            _ => Err(EOVERFLOW),
+        }
+    }
+}

--- a/src/v2/src/guest/call/gdbcall/write_all.rs
+++ b/src/v2/src/guest/call/gdbcall/write_all.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::types::Argv;
+use super::types::StagedBytesInput;
+use super::Alloc;
+use crate::guest::alloc::{Allocator, Collector, Input};
+use crate::item::gdbcall::Number;
+use crate::Result;
+
+#[cfg_attr(feature = "doc", doc = "[`gdbstub::conn::Connection::write_all`] call")]
+pub struct WriteAll<'a> {
+    pub buf: &'a [u8],
+}
+
+impl<'a> Alloc<'a> for WriteAll<'a> {
+    const NUM: Number = Number::WriteAll;
+
+    type Argv = Argv<2>;
+    type Ret = usize;
+
+    type Staged = StagedBytesInput<'a>;
+    type Committed = usize;
+    type Collected = Option<Result<usize>>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let (buf, _) = Input::stage_slice_max(alloc, self.buf)?;
+        Ok((Argv([buf.offset(), buf.len()]), StagedBytesInput(buf)))
+    }
+
+    fn collect(
+        count: Self::Committed,
+        ret: Result<Self::Ret>,
+        _: &impl Collector,
+    ) -> Self::Collected {
+        match ret {
+            Ok(ret) if ret > count => None,
+            res @ Ok(_) => Some(res),
+            err => Some(err),
+        }
+    }
+}

--- a/src/v2/src/guest/call/mod.rs
+++ b/src/v2/src/guest/call/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod alloc;
 pub mod syscall;
+pub mod types;
 
 mod maybe_alloc;
 mod stub;

--- a/src/v2/src/guest/call/mod.rs
+++ b/src/v2/src/guest/call/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod alloc;
+pub mod gdbcall;
 pub mod syscall;
 pub mod types;
 

--- a/src/v2/src/guest/call/syscall/accept.rs
+++ b/src/v2/src/guest/call/syscall/accept.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
+use super::super::types::Argv;
+use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
 use crate::{Result, NULL};

--- a/src/v2/src/guest/call/syscall/accept4.rs
+++ b/src/v2/src/guest/call/syscall/accept4.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
+use super::super::types::Argv;
+use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
 use crate::{Result, NULL};

--- a/src/v2/src/guest/call/syscall/alloc.rs
+++ b/src/v2/src/guest/call/syscall/alloc.rs
@@ -12,7 +12,7 @@ use libc::c_long;
 /// # Examples
 ///
 /// ```rust
-/// use sallyport::guest::syscall::types::Argv;
+/// use sallyport::guest::call::types::Argv;
 /// # use sallyport::guest::alloc::{Allocator, Collector, Output};
 /// # use sallyport::guest::syscall::Alloc;
 /// # use sallyport::Result;
@@ -63,7 +63,7 @@ pub unsafe trait Alloc<'a> {
 
     /// The syscall argument vector.
     ///
-    /// For example, [`crate::guest::syscall::types::Argv<3>`].
+    /// For example, [`crate::guest::call::types::Argv<3>`].
     type Argv: Into<[usize; 6]>;
 
     /// Syscall return value.

--- a/src/v2/src/guest/call/syscall/alloc.rs
+++ b/src/v2/src/guest/call/syscall/alloc.rs
@@ -12,10 +12,10 @@ use libc::c_long;
 /// # Examples
 ///
 /// ```rust
+/// use sallyport::guest::alloc::{Allocator, Collector, Output};
 /// use sallyport::guest::call::types::Argv;
-/// # use sallyport::guest::alloc::{Allocator, Collector, Output};
-/// # use sallyport::guest::syscall::Alloc;
-/// # use sallyport::Result;
+/// use sallyport::guest::syscall::Alloc;
+/// use sallyport::Result;
 /// #
 /// # use libc::{c_int, c_long, size_t};
 ///
@@ -63,7 +63,7 @@ pub unsafe trait Alloc<'a> {
 
     /// The syscall argument vector.
     ///
-    /// For example, [`crate::guest::call::types::Argv<3>`].
+    /// For example, [`guest::call::types::Argv<3>`](super::super::types::Argv<3>).
     type Argv: Into<[usize; 6]>;
 
     /// Syscall return value.
@@ -78,8 +78,10 @@ pub unsafe trait Alloc<'a> {
     /// For example, [`Output<'a, [u8], &'a mut [u8]>`](crate::guest::alloc::Output).
     type Staged: Commit<Item = Self::Committed>;
 
-    /// Opaque [committed value](crate::guest::alloc::Commit::Item) returned by [`crate::guest::alloc::Commit::commit`] called upon [`Self::Staged`],
-    /// which returns [`Self::Collected`] when collected via [`crate::guest::alloc::Collect::collect`].
+    /// Opaque [committed value](crate::guest::alloc::Commit::Item)
+    /// returned by [`guest::alloc::Commit::commit`](crate::guest::alloc::Commit::commit)
+    /// called upon [`Self::Staged`], which returns [`Self::Collected`] when
+    /// collected via [`guest::alloc::Collect::collect`](crate::guest::alloc::Collect::collect).
     type Committed;
 
     /// Value syscall [collects](crate::guest::alloc::Collect::Item) as, which corresponds to its [return value](Self::Ret).

--- a/src/v2/src/guest/call/syscall/bind.rs
+++ b/src/v2/src/guest/call/syscall/bind.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, SockaddrInput, StagedSockaddrInput};
+use super::super::types::Argv;
+use super::types::{SockaddrInput, StagedSockaddrInput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Stage};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/clock_gettime.rs
+++ b/src/v2/src/guest/call/syscall/clock_gettime.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Output};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/connect.rs
+++ b/src/v2/src/guest/call/syscall/connect.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, SockaddrInput};
+use super::super::types::Argv;
+use super::types::SockaddrInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input, Stage};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/epoll_ctl.rs
+++ b/src/v2/src/guest/call/syscall/epoll_ctl.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/epoll_pwait.rs
+++ b/src/v2/src/guest/call/syscall/epoll_pwait.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Input, Output};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/epoll_wait.rs
+++ b/src/v2/src/guest/call/syscall/epoll_wait.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/fcntl.rs
+++ b/src/v2/src/guest/call/syscall/fcntl.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use super::super::types::Argv;
 use super::super::Alloc;
-use super::types::Argv;
 use super::PassthroughAlloc;
 use crate::guest::alloc::Allocator;
 use crate::guest::call::alloc::kind;

--- a/src/v2/src/guest/call/syscall/getsockname.rs
+++ b/src/v2/src/guest/call/syscall/getsockname.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
+use super::super::types::Argv;
+use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/ioctl.rs
+++ b/src/v2/src/guest/call/syscall/ioctl.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, InOut, Output};
 use crate::{Result, NULL};

--- a/src/v2/src/guest/call/syscall/passthrough.rs
+++ b/src/v2/src/guest/call/syscall/passthrough.rs
@@ -13,8 +13,8 @@ use libc::{c_int, c_long};
 /// # Example
 /// ```rust
 /// use sallyport::guest::call::types::Argv;
-/// # use sallyport::guest::syscall::PassthroughAlloc;
-/// # use sallyport::Result;
+/// use sallyport::guest::syscall::PassthroughAlloc;
+/// use sallyport::Result;
 /// #
 /// # use libc::{c_int, c_long};
 ///
@@ -41,7 +41,7 @@ pub unsafe trait PassthroughAlloc {
 
     /// The syscall argument vector.
     ///
-    /// For example, [`super::types::Argv<1>`].
+    /// For example, [`call::types::Argv<1>`](crate::guest::call::types::Argv<1>).
     type Argv: Into<[usize; 6]>;
 
     /// Syscall return value.

--- a/src/v2/src/guest/call/syscall/passthrough.rs
+++ b/src/v2/src/guest/call/syscall/passthrough.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector};
 use crate::Result;
@@ -12,7 +12,7 @@ use libc::{c_int, c_long};
 ///
 /// # Example
 /// ```rust
-/// use sallyport::guest::syscall::types::Argv;
+/// use sallyport::guest::call::types::Argv;
 /// # use sallyport::guest::syscall::PassthroughAlloc;
 /// # use sallyport::Result;
 /// #

--- a/src/v2/src/guest/call/syscall/poll.rs
+++ b/src/v2/src/guest/call/syscall/poll.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/read.rs
+++ b/src/v2/src/guest/call/syscall/read.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/readv.rs
+++ b/src/v2/src/guest/call/syscall/readv.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::{iov_len, Alloc};
 use crate::guest::alloc::{Allocator, Collector, CommitPassthrough, OutRef};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/recv.rs
+++ b/src/v2/src/guest/call/syscall/recv.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/recvfrom.rs
+++ b/src/v2/src/guest/call/syscall/recvfrom.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
+use super::super::types::Argv;
+use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Output, Stage};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/send.rs
+++ b/src/v2/src/guest/call/syscall/send.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, StagedBytesInput};
+use super::super::types::Argv;
+use super::types::StagedBytesInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/sendto.rs
+++ b/src/v2/src/guest/call/syscall/sendto.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, SockaddrInput, StagedBytesInput};
+use super::super::types::Argv;
+use super::types::{SockaddrInput, StagedBytesInput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input, Stage};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/setsockopt.rs
+++ b/src/v2/src/guest/call/syscall/setsockopt.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, SockoptInput};
+use super::super::types::Argv;
+use super::types::SockoptInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Stage};
 use crate::{Result, NULL};

--- a/src/v2/src/guest/call/syscall/tests.rs
+++ b/src/v2/src/guest/call/syscall/tests.rs
@@ -5,7 +5,7 @@ use crate::guest::alloc::{Alloc, Allocator, Collect, Commit, Committer};
 use crate::guest::call::kind;
 use crate::guest::syscall::types::SockaddrOutput;
 use crate::guest::Call;
-use crate::item::{self, SYSCALL_USIZE_COUNT};
+use crate::item::{self, syscall};
 use crate::NULL;
 
 use core::mem::size_of;
@@ -39,7 +39,7 @@ fn exit() {
     assert_call(
         Exit { status: 2 },
         [
-            SYSCALL_USIZE_COUNT * size_of::<usize>(),
+            syscall::USIZE_COUNT * size_of::<usize>(),
             item::Kind::Syscall as _,
             libc::SYS_exit as _,
             2,
@@ -69,7 +69,7 @@ fn recv() {
             flags,
         },
         [
-            SYSCALL_USIZE_COUNT * size_of::<usize>() + size_of::<usize>(),
+            syscall::USIZE_COUNT * size_of::<usize>() + size_of::<usize>(),
             item::Kind::Syscall as _,
             libc::SYS_recvfrom as _,
             sockfd as _,
@@ -106,7 +106,7 @@ fn recvfrom() {
             src_addr: SockaddrOutput::new(&mut src_addr, &mut addrlen),
         },
         [
-            SYSCALL_USIZE_COUNT * size_of::<usize>() + 2 * size_of::<usize>(),
+            syscall::USIZE_COUNT * size_of::<usize>() + 2 * size_of::<usize>(),
             item::Kind::Syscall as _,
             libc::SYS_recvfrom as _,
             sockfd as _,

--- a/src/v2/src/guest/call/syscall/types/mod.rs
+++ b/src/v2/src/guest/call/syscall/types/mod.rs
@@ -3,14 +3,12 @@
 //! Syscall-specific types.
 
 mod alloc;
-mod argv;
 mod bytes;
 mod result;
 mod sockaddr;
 mod sockopt;
 
 pub use alloc::*;
-pub use argv::*;
 pub use bytes::*;
 pub use result::*;
 pub use sockaddr::*;

--- a/src/v2/src/guest/call/syscall/write.rs
+++ b/src/v2/src/guest/call/syscall/write.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{Argv, StagedBytesInput};
+use super::super::types::Argv;
+use super::types::StagedBytesInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;

--- a/src/v2/src/guest/call/syscall/writev.rs
+++ b/src/v2/src/guest/call/syscall/writev.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::Argv;
+use super::super::types::Argv;
 use super::{iov_len, Alloc};
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, InRef};
 use crate::Result;

--- a/src/v2/src/guest/call/types/argv.rs
+++ b/src/v2/src/guest/call/types/argv.rs
@@ -5,10 +5,31 @@ use crate::NULL;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Argv<const N: usize>(pub [usize; N]);
 
+impl<const N: usize> From<Argv<N>> for [usize; N] {
+    #[inline]
+    fn from(argv: Argv<N>) -> Self {
+        argv.0
+    }
+}
+
+impl From<Argv<0>> for [usize; 4] {
+    #[inline]
+    fn from(_: Argv<0>) -> Self {
+        [NULL, NULL, NULL, NULL]
+    }
+}
+
 impl From<Argv<0>> for [usize; 6] {
     #[inline]
     fn from(_: Argv<0>) -> Self {
         [NULL, NULL, NULL, NULL, NULL, NULL]
+    }
+}
+
+impl From<Argv<1>> for [usize; 4] {
+    #[inline]
+    fn from(argv: Argv<1>) -> Self {
+        [argv.0[0], NULL, NULL, NULL]
     }
 }
 
@@ -19,10 +40,24 @@ impl From<Argv<1>> for [usize; 6] {
     }
 }
 
+impl From<Argv<2>> for [usize; 4] {
+    #[inline]
+    fn from(argv: Argv<2>) -> Self {
+        [argv.0[0], argv.0[1], NULL, NULL]
+    }
+}
+
 impl From<Argv<2>> for [usize; 6] {
     #[inline]
     fn from(argv: Argv<2>) -> Self {
         [argv.0[0], argv.0[1], NULL, NULL, NULL, NULL]
+    }
+}
+
+impl From<Argv<3>> for [usize; 4] {
+    #[inline]
+    fn from(argv: Argv<3>) -> Self {
+        [argv.0[0], argv.0[1], argv.0[2], NULL]
     }
 }
 
@@ -44,12 +79,5 @@ impl From<Argv<5>> for [usize; 6] {
     #[inline]
     fn from(argv: Argv<5>) -> Self {
         [argv.0[0], argv.0[1], argv.0[2], argv.0[3], argv.0[4], NULL]
-    }
-}
-
-impl From<Argv<6>> for [usize; 6] {
-    #[inline]
-    fn from(argv: Argv<6>) -> Self {
-        argv.0
     }
 }

--- a/src/v2/src/guest/call/types/mod.rs
+++ b/src/v2/src/guest/call/types/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Call-specific types.
+
+mod argv;
+
+pub use argv::*;

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -59,7 +59,7 @@ mod handler;
 mod platform;
 mod tls;
 
-pub use call::{syscall, gdbcall, Call};
+pub use call::{gdbcall, syscall, Call};
 pub use handler::*;
 pub use platform::*;
 pub use tls::*;

--- a/src/v2/src/guest/mod.rs
+++ b/src/v2/src/guest/mod.rs
@@ -59,7 +59,7 @@ mod handler;
 mod platform;
 mod tls;
 
-pub use call::{syscall, Call};
+pub use call::{syscall, gdbcall, Call};
 pub use handler::*;
 pub use platform::*;
 pub use tls::*;

--- a/src/v2/src/item/gdbcall.rs
+++ b/src/v2/src/item/gdbcall.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::mem::size_of;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(usize)]
+/// Number of an [`Item`](super::Item) of [`Kind::Gdbcall`](super::Kind::Gdbcall).
+pub enum Number {
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Call number coresponding to [gdbstub::conn::Connection::write]"
+    )]
+    Write = 0x00,
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Call number coresponding to [gdbstub::conn::Connection::write_all]"
+    )]
+    WriteAll = 0x02,
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Call number coresponding to [gdbstub::conn::Connection::flush]"
+    )]
+    Flush = 0x03,
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Call number coresponding to [gdbstub::conn::Connection::on_session_start]"
+    )]
+    OnSessionStart = 0x04,
+
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Call number coresponding to [gdbstub::conn::ConnectionExt::read]"
+    )]
+    Read = 0x05,
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Call number coresponding to [gdbstub::conn::ConnectionExt::peek]"
+    )]
+    Peek = 0x06,
+}
+
+/// Payload of an [`Item`](super::Item) of [`Kind::Gdbcall`](super::Kind::Gdbcall).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C, align(8))]
+pub struct Payload {
+    pub num: Number,
+    pub argv: [usize; 4],
+    pub ret: usize,
+}
+
+pub(crate) const USIZE_COUNT: usize = size_of::<Payload>() / size_of::<usize>();
+
+impl From<&mut [usize; USIZE_COUNT]> for &mut Payload {
+    #[inline]
+    fn from(buf: &mut [usize; USIZE_COUNT]) -> Self {
+        debug_assert_eq!(size_of::<Payload>(), USIZE_COUNT * size_of::<usize>());
+        unsafe { &mut *(buf as *mut _ as *mut _) }
+    }
+}

--- a/src/v2/src/item/syscall.rs
+++ b/src/v2/src/item/syscall.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::mem::size_of;
+
+/// Payload of an [`Item`](super::Item) of [`Kind::Syscall`](super::Kind::Syscall).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C, align(8))]
+pub struct Payload {
+    pub num: usize,
+    pub argv: [usize; 6],
+    pub ret: [usize; 2],
+}
+
+pub(crate) const USIZE_COUNT: usize = size_of::<Payload>() / size_of::<usize>();
+
+impl From<&mut [usize; USIZE_COUNT]> for &mut Payload {
+    #[inline]
+    fn from(buf: &mut [usize; USIZE_COUNT]) -> Self {
+        debug_assert_eq!(size_of::<Payload>(), USIZE_COUNT * size_of::<usize>());
+        unsafe { &mut *(buf as *mut _ as *mut _) }
+    }
+}


### PR DESCRIPTION
Part of enarx/sallyport#34

NOTE: I will go through the docs of the crate as a whole in enarx/enarx#1725 

I followed the structure of https://docs.rs/gdbstub/latest/gdbstub/conn/index.html traits directly.
Shims may or may not actually use all of these calls or implement functionality on top of this.