### PR TITLE
fix: use `libc::Ioctl` instead of `c_ulong`

### DIFF
--- a/src/syscall/file.rs
+++ b/src/syscall/file.rs
@@ -129,7 +129,7 @@ pub trait FileSyscallHandler: BaseSyscallHandler + AddressValidator + Sized {
     }
 
     /// syscall
-    fn ioctl(&mut self, fd: libc::c_int, request: libc::c_ulong, arg: usize) -> Result {
+    fn ioctl(&mut self, fd: libc::c_int, request: libc::Ioctl, arg: usize) -> Result {
         self.trace("ioctl", 3);
         match (fd as _, request as _) {
             (libc::STDIN_FILENO, libc::TIOCGWINSZ)

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -216,7 +216,7 @@ pub trait SyscallHandler:
             libc::SYS_readv => self.readv(usize::from(a) as _, b.into(), usize::from(c) as _),
             libc::SYS_write => self.write(usize::from(a) as _, b.into(), c.into()),
             libc::SYS_writev => self.writev(usize::from(a) as _, b.into(), usize::from(c) as _),
-            libc::SYS_ioctl => self.ioctl(usize::from(a) as _, b.into(), c.into()),
+            libc::SYS_ioctl => self.ioctl(usize::from(a) as _, usize::from(b) as _, c.into()),
             libc::SYS_readlink => self.readlink(a.into(), b.into(), c.into()),
             libc::SYS_fstat => self.fstat(usize::from(a) as _, b.into()),
             libc::SYS_fcntl => self.fcntl(

--- a/src/v2/src/guest/call/syscall/ioctl.rs
+++ b/src/v2/src/guest/call/syscall/ioctl.rs
@@ -5,11 +5,11 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, InOut, Output};
 use crate::{Result, NULL};
 
-use libc::{c_int, c_long, c_ulong};
+use libc::{c_int, c_long};
 
 pub struct Ioctl<'a> {
     pub fd: c_int,
-    pub request: c_ulong,
+    pub request: libc::Ioctl,
     pub argp: Option<&'a mut [u8]>,
 }
 

--- a/src/v2/src/guest/handler.rs
+++ b/src/v2/src/guest/handler.rs
@@ -11,8 +11,9 @@ use core::slice;
 
 use libc::{
     c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, off_t, pid_t, pollfd, sigaction,
-    sigset_t, size_t, stack_t, stat, timespec, uid_t, utsname, EBADFD, EFAULT, EINVAL, ENOSYS,
-    ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ,
+    sigset_t, size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT, EINVAL,
+    ENOSYS, ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+    TIOCGWINSZ,
 };
 
 pub trait Execute {
@@ -219,7 +220,7 @@ pub trait Execute {
     }
 
     /// Executes [`ioctl`](https://man7.org/linux/man-pages/man2/ioctl.2.html) syscall akin to [`libc::ioctl`].
-    fn ioctl(&mut self, fd: c_int, request: c_ulong, argp: Option<&mut [u8]>) -> Result<c_int> {
+    fn ioctl(&mut self, fd: c_int, request: Ioctl, argp: Option<&mut [u8]>) -> Result<c_int> {
         match (fd, request) {
             (STDIN_FILENO | STDOUT_FILENO | STDERR_FILENO, TIOCGWINSZ) => {
                 // the keep has no tty


### PR DESCRIPTION
Apparently `x86_64-unknown-linux-musl` and `x86_64-unknown-linux-gnu`
differ now in this type.

Signed-off-by: Harald Hoyer <harald@profian.com>

Fixes: #86 