### PR TITLE
feat: add support for Enarx calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ libc = { version = "0.2", features = [] }
 [dev-dependencies]
 libc = { version = "0.2", features = [ "extra_traits" ] }
 serial_test = "0.6"
+memoffset = "0.6.5"
 
 [features]
 doc = [ "gdbstub" ]

--- a/src/guest/call/alloc.rs
+++ b/src/guest/call/alloc.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Generic allocatable call-specific functionality.
+
 use super::Call;
 use crate::guest::alloc::{Allocator, Collect, Collector, Commit, Committer, InRef};
 use crate::{item, Result};
@@ -8,6 +10,7 @@ use core::alloc::Layout;
 use core::mem::align_of;
 use libc::ENOMEM;
 
+/// Allocatable call kinds.
 pub(crate) mod kind {
     use super::Alloc;
     use crate::item;

--- a/src/guest/call/alloc.rs
+++ b/src/guest/call/alloc.rs
@@ -32,6 +32,12 @@ pub(crate) mod kind {
     }
 
     #[repr(transparent)]
+    pub struct Enarxcall;
+    impl Kind for Enarxcall {
+        const ITEM: item::Kind = item::Kind::Enarxcall;
+    }
+
+    #[repr(transparent)]
     pub struct MaybeAlloc<'a, K: Kind, T: Alloc<'a, K>>(&'a PhantomData<(K, T)>);
     impl<'a, K: Kind, T: Alloc<'a, K>> Kind for MaybeAlloc<'a, K, T> {
         const ITEM: item::Kind = K::ITEM;

--- a/src/guest/call/enarxcall/alloc.rs
+++ b/src/guest/call/enarxcall/alloc.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::alloc;
+use super::types::{self, CommittedAlloc, StagedAlloc};
+use crate::guest::alloc::{Allocator, Collector, Commit};
+use crate::item::enarxcall::Number;
+use crate::Result;
+
+/// A generic Enarx call, which can be allocated within the block.
+pub trait Alloc<'a> {
+    /// Enarx call number.
+    const NUM: Number;
+
+    /// The Enarx call argument vector.
+    ///
+    /// For example, [`guest::call::types::Argv<2>`](super::super::types::Argv<2>).
+    type Argv: Into<[usize; 4]>;
+
+    /// Enarx call return value.
+    ///
+    /// For example, [`usize`].
+    type Ret;
+
+    /// Opaque staged value, which returns [`Self::Committed`] when committed via [`Commit::commit`].
+    ///
+    /// This is designed to serve as a container for dynamic data allocated within [`stage`][Self::stage].
+    ///
+    /// For example, [`Input<'a, [u8], &'a [u8]>`](crate::guest::alloc::Input).
+    type Staged: Commit<Item = Self::Committed>;
+
+    /// Opaque [committed value](crate::guest::alloc::Commit::Item)
+    /// returned by [`guest::alloc::Commit::commit`](crate::guest::alloc::Commit::commit)
+    /// called upon [`Self::Staged`], which returns [`Self::Collected`] when
+    /// collected via [`guest::alloc::Collect::collect`](crate::guest::alloc::Collect::collect).
+    type Committed;
+
+    /// Value Enarx call [collects](crate::guest::alloc::Collect::Item) as, which corresponds to its [return value](Self::Ret).
+    ///
+    /// For example, [`Option<Result<usize>>`].
+    type Collected;
+
+    /// Allocate dynamic data, if necessary and return resulting argument vector registers
+    /// and opaque [staged value](Self::Staged) on success.
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)>;
+
+    /// Collect the return registers, [opaque committed value](Self::Committed)
+    /// and return a [`Self::Collected`].
+    fn collect(
+        committed: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected;
+}
+
+impl<'a, T: Alloc<'a>> super::super::Alloc<'a, alloc::kind::Enarxcall> for T
+where
+    types::Result<T::Ret>: Into<Result<T::Ret>>,
+{
+    type Staged = StagedAlloc<'a, T>;
+    type Committed = CommittedAlloc<'a, T>;
+    type Collected = T::Collected;
+
+    #[inline]
+    fn stage(self, alloc: &mut impl Allocator) -> Result<Self::Staged> {
+        let num_ref = alloc.allocate_input()?;
+        let argv_ref = alloc.allocate_input()?;
+        let ret_ref = alloc.allocate_inout()?;
+        let ((argv, staged), _) = alloc.section(|alloc| self.stage(alloc))?;
+        Ok(Self::Staged {
+            num_ref,
+            argv: argv_ref.stage(argv.into()),
+            ret_ref,
+            staged,
+        })
+    }
+}

--- a/src/guest/call/enarxcall/alloc.rs
+++ b/src/guest/call/enarxcall/alloc.rs
@@ -9,6 +9,8 @@ use crate::Result;
 /// A generic Enarx call, which can be allocated within the block.
 pub trait Alloc<'a> {
     /// Enarx call number.
+    ///
+    /// For example, [`item::enarxcall::Number::Cpuid`](Number::Cpuid).
     const NUM: Number;
 
     /// The Enarx call argument vector.

--- a/src/guest/call/enarxcall/cpuid.rs
+++ b/src/guest/call/enarxcall/cpuid.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::types::Argv;
+use super::Alloc;
+use crate::guest::alloc::{Allocator, Collect, Collector, Output};
+use crate::item::enarxcall::Number;
+use crate::Result;
+
+use core::arch::x86_64::CpuidResult;
+
+/// Cpuid Enarx call, which writes the [result](CpuidResult) of the `cpuid` instruction
+/// for a given `leaf` (`EAX`) and `sub_leaf` (`ECX`) in `result` field.
+pub struct Cpuid<'a> {
+    pub leaf: u32,
+    pub sub_leaf: u32,
+    pub result: &'a mut CpuidResult,
+}
+
+impl<'a> Alloc<'a> for Cpuid<'a> {
+    const NUM: Number = Number::Cpuid;
+
+    type Argv = Argv<3>;
+    type Ret = ();
+
+    type Staged = Output<'a, CpuidResult, &'a mut CpuidResult>;
+    type Committed = Self::Staged;
+    type Collected = Result<()>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let result = Output::stage(alloc, self.result)?;
+        Ok((
+            Argv([self.leaf as _, self.sub_leaf as _, result.offset()]),
+            result,
+        ))
+    }
+
+    fn collect(
+        result: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected {
+        if ret.is_ok() {
+            result.collect(col);
+        }
+        ret
+    }
+}

--- a/src/guest/call/enarxcall/get_sgx_quote.rs
+++ b/src/guest/call/enarxcall/get_sgx_quote.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::types::Argv;
+use super::Alloc;
+use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Input, Output};
+use crate::item::enarxcall::sgx::Report;
+use crate::item::enarxcall::Number;
+use crate::Result;
+
+use core::mem::size_of;
+
+// GetSgxQuote call, which writes the SGX quote in `quote` field.
+pub struct GetSgxQuote<'a> {
+    pub report: &'a Report,
+    pub quote: &'a mut [u8],
+}
+
+pub struct StagedGetSgxQuote<'a> {
+    report: Input<'a, [u8; size_of::<Report>()], &'a [u8; size_of::<Report>()]>,
+    quote: Output<'a, [u8], &'a mut [u8]>,
+}
+
+impl<'a> Commit for StagedGetSgxQuote<'a> {
+    type Item = Output<'a, [u8], &'a mut [u8]>;
+
+    fn commit(self, com: &impl Committer) -> Self::Item {
+        self.report.commit(com);
+        self.quote.commit(com)
+    }
+}
+
+impl<'a> Alloc<'a> for GetSgxQuote<'a> {
+    const NUM: Number = Number::GetSgxQuote;
+
+    type Argv = Argv<3>;
+    type Ret = usize;
+
+    type Staged = StagedGetSgxQuote<'a>;
+    type Committed = Output<'a, [u8], &'a mut [u8]>;
+    type Collected = Option<Result<usize>>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let report = Input::stage(alloc, self.report.as_ref())?;
+        let quote = Output::stage_slice(alloc, self.quote)?;
+        Ok((
+            Argv([report.offset(), quote.offset(), quote.len()]),
+            StagedGetSgxQuote { report, quote },
+        ))
+    }
+
+    fn collect(
+        quote: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected {
+        match ret {
+            Ok(ret) if ret > quote.len() => None,
+            res @ Ok(ret) => {
+                unsafe { quote.collect_range(col, 0..ret) };
+                Some(res)
+            }
+            err => Some(err),
+        }
+    }
+}

--- a/src/guest/call/enarxcall/get_sgx_target_info.rs
+++ b/src/guest/call/enarxcall/get_sgx_target_info.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::types::Argv;
+use super::Alloc;
+use crate::guest::alloc::{Allocator, Collect, Collector, Output};
+use crate::item::enarxcall::sgx::TargetInfo;
+use crate::item::enarxcall::Number;
+use crate::Result;
+
+use core::mem::size_of;
+
+// GetSgxTargetInfo call, which writes the [SGX `TargetInfo`](TargetInfo) in `info` field.
+pub struct GetSgxTargetInfo<'a> {
+    pub info: &'a mut TargetInfo,
+}
+
+impl<'a> Alloc<'a> for GetSgxTargetInfo<'a> {
+    const NUM: Number = Number::GetSgxTargetInfo;
+
+    type Argv = Argv<1>;
+    type Ret = ();
+
+    type Staged = Output<'a, [u8; size_of::<TargetInfo>()], &'a mut [u8; size_of::<TargetInfo>()]>;
+    type Committed = Self::Staged;
+    type Collected = Result<()>;
+
+    fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        let info = Output::stage(alloc, self.info.as_mut())?;
+        Ok((Argv([info.offset()]), info))
+    }
+
+    fn collect(
+        info: Self::Committed,
+        ret: Result<Self::Ret>,
+        col: &impl Collector,
+    ) -> Self::Collected {
+        if ret.is_ok() {
+            info.collect(col);
+        }
+        ret
+    }
+}

--- a/src/guest/call/enarxcall/get_sgx_target_info.rs
+++ b/src/guest/call/enarxcall/get_sgx_target_info.rs
@@ -7,8 +7,6 @@ use crate::item::enarxcall::sgx::TargetInfo;
 use crate::item::enarxcall::Number;
 use crate::Result;
 
-use core::mem::size_of;
-
 // GetSgxTargetInfo call, which writes the [SGX `TargetInfo`](TargetInfo) in `info` field.
 pub struct GetSgxTargetInfo<'a> {
     pub info: &'a mut TargetInfo,
@@ -20,7 +18,7 @@ impl<'a> Alloc<'a> for GetSgxTargetInfo<'a> {
     type Argv = Argv<1>;
     type Ret = ();
 
-    type Staged = Output<'a, [u8; size_of::<TargetInfo>()], &'a mut [u8; size_of::<TargetInfo>()]>;
+    type Staged = Output<'a, [u8; 512], &'a mut [u8; 512]>;
     type Committed = Self::Staged;
     type Collected = Result<()>;
 
@@ -38,5 +36,15 @@ impl<'a> Alloc<'a> for GetSgxTargetInfo<'a> {
             info.collect(col);
         }
         ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_info_size() {
+        assert_eq!(core::mem::size_of::<TargetInfo>(), 512);
     }
 }

--- a/src/guest/call/enarxcall/mod.rs
+++ b/src/guest/call/enarxcall/mod.rs
@@ -3,9 +3,11 @@
 //! Enarx call-specific functionality.
 
 mod alloc;
+mod cpuid;
 mod passthrough;
 
 pub mod types;
 
 pub use alloc::*;
+pub use cpuid::*;
 pub use passthrough::*;

--- a/src/guest/call/enarxcall/mod.rs
+++ b/src/guest/call/enarxcall/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Enarx call-specific functionality.
+
+mod alloc;
+mod passthrough;
+
+pub mod types;
+
+pub use alloc::*;
+pub use passthrough::*;

--- a/src/guest/call/enarxcall/mod.rs
+++ b/src/guest/call/enarxcall/mod.rs
@@ -4,10 +4,14 @@
 
 mod alloc;
 mod cpuid;
+mod get_sgx_quote;
+mod get_sgx_target_info;
 mod passthrough;
 
 pub mod types;
 
 pub use alloc::*;
 pub use cpuid::*;
+pub use get_sgx_quote::*;
+pub use get_sgx_target_info::*;
 pub use passthrough::*;

--- a/src/guest/call/enarxcall/passthrough.rs
+++ b/src/guest/call/enarxcall/passthrough.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Alloc;
+use crate::guest::alloc::{Allocator, Collector};
+use crate::item::enarxcall::Number;
+use crate::Result;
+
+/// Trait implemented by allocatable Enarx calls, which are passed through directly to the host and do
+/// not require custom handling logic.
+pub trait PassthroughAlloc {
+    /// Enarx call number.
+    ///
+    /// For example, [`Number::BalloonMemory`].
+    const NUM: Number;
+
+    /// The Enarx call argument vector.
+    ///
+    /// For example, [`call::types::Argv<3>`](crate::guest::call::types::Argv<3>).
+    type Argv: Into<[usize; 4]>;
+
+    /// Enarx call return value.
+    ///
+    /// For example, `usize`.
+    type Ret;
+
+    /// Returns argument vector registers.
+    fn stage(self) -> Self::Argv;
+}
+
+impl<'a, T: PassthroughAlloc> Alloc<'a> for T {
+    const NUM: Number = T::NUM;
+
+    type Argv = T::Argv;
+    type Ret = T::Ret;
+
+    type Staged = ();
+    type Committed = ();
+    type Collected = Result<T::Ret>;
+
+    fn stage(self, _: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
+        Ok((T::stage(self), ()))
+    }
+
+    fn collect(_: Self::Committed, ret: Result<Self::Ret>, _: &impl Collector) -> Self::Collected {
+        ret
+    }
+}

--- a/src/guest/call/enarxcall/passthrough.rs
+++ b/src/guest/call/enarxcall/passthrough.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use libc::c_void;
+
+use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector};
 use crate::item::enarxcall::Number;
@@ -43,5 +46,41 @@ impl<'a, T: PassthroughAlloc> Alloc<'a> for T {
 
     fn collect(_: Self::Committed, ret: Result<Self::Ret>, _: &impl Collector) -> Self::Collected {
         ret
+    }
+}
+
+/// Request an additional memory region.
+pub struct BalloonMemory {
+    /// Page size expressed as an exponent of 2.
+    pub size_exponent: usize,
+    /// Number of pages to allocate.
+    pub pages: usize,
+    /// Guest physical address where the memory should be allocated.
+    pub addr: *mut c_void,
+}
+
+impl PassthroughAlloc for BalloonMemory {
+    const NUM: Number = Number::BalloonMemory;
+
+    type Argv = Argv<3>;
+    type Ret = usize;
+
+    fn stage(self) -> Self::Argv {
+        Argv([self.size_exponent, self.pages, self.addr as _])
+    }
+}
+
+/// Get number of memory slots available for ballooning from the host.
+#[repr(transparent)]
+pub struct MemInfo;
+
+impl PassthroughAlloc for MemInfo {
+    const NUM: Number = Number::MemInfo;
+
+    type Argv = Argv<0>;
+    type Ret = usize;
+
+    fn stage(self) -> Self::Argv {
+        Argv([])
     }
 }

--- a/src/guest/call/enarxcall/types/alloc.rs
+++ b/src/guest/call/enarxcall/types/alloc.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::Alloc;
+use crate::guest::alloc::{Collect, Collector, Commit, Committer, InOutRef, InRef, Input, OutRef};
+use crate::Result;
+
+/// Staged Enarx call, which holds allocated reference to Enarx call item within the block and [opaque staged value](Alloc::Staged).
+pub struct StagedAlloc<'a, T: Alloc<'a>> {
+    pub(crate) num_ref: InRef<'a, usize>,
+    pub(crate) argv: Input<'a, [usize; 4], [usize; 4]>,
+    pub(crate) ret_ref: InOutRef<'a, usize>,
+    pub(crate) staged: T::Staged,
+}
+
+impl<'a, T: Alloc<'a>> Commit for StagedAlloc<'a, T> {
+    type Item = CommittedAlloc<'a, T>;
+
+    #[inline]
+    fn commit(mut self, com: &impl Committer) -> Self::Item {
+        self.num_ref.copy_from(com, T::NUM as usize);
+        self.argv.commit(com);
+        self.ret_ref.copy_from(com, -libc::ENOSYS as usize);
+        Self::Item {
+            ret_ref: self.ret_ref.commit(com),
+            committed: self.staged.commit(com),
+        }
+    }
+}
+
+/// Committed Enarx call, which holds allocated reference to Enarx call return values within the block and [opaque committed value](Alloc::Committed).
+pub struct CommittedAlloc<'a, T: Alloc<'a>> {
+    pub(crate) ret_ref: OutRef<'a, usize>,
+    pub(crate) committed: T::Committed,
+}
+
+impl<'a, T: Alloc<'a>> Collect for CommittedAlloc<'a, T>
+where
+    super::Result<T::Ret>: Into<Result<T::Ret>>,
+{
+    type Item = T::Collected;
+
+    #[inline]
+    fn collect(self, col: &impl Collector) -> Self::Item {
+        let mut ret = 0usize;
+        self.ret_ref.copy_to(col, &mut ret);
+        let res: super::Result<T::Ret> = ret.into();
+        T::collect(self.committed, res.into(), col)
+    }
+}

--- a/src/guest/call/enarxcall/types/mod.rs
+++ b/src/guest/call/enarxcall/types/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Enarxcall-specific types.
+
+mod alloc;
+mod result;
+
+pub use alloc::*;
+pub use result::*;

--- a/src/guest/call/enarxcall/types/result.rs
+++ b/src/guest/call/enarxcall/types/result.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::marker::PhantomData;
+use libc::c_int;
+
+pub const MAX_ERRNO: c_int = 4096;
+pub const ERRNO_START: usize = usize::MAX - MAX_ERRNO as usize;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Result<T>(usize, PhantomData<T>);
+
+impl<T> From<Result<T>> for usize {
+    #[inline]
+    fn from(res: Result<T>) -> Self {
+        res.0
+    }
+}
+
+impl<T> From<usize> for Result<T> {
+    #[inline]
+    fn from(ret: usize) -> Self {
+        Self(ret, PhantomData)
+    }
+}
+
+impl From<Result<()>> for crate::Result<()> {
+    #[inline]
+    fn from(res: Result<()>) -> Self {
+        match res.0 {
+            errno @ ERRNO_START..=usize::MAX => Err(-(errno as c_int)),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl From<Result<usize>> for crate::Result<usize> {
+    #[inline]
+    fn from(res: Result<usize>) -> Self {
+        match res.0 {
+            errno @ ERRNO_START..=usize::MAX => Err(-(errno as c_int)),
+            ret => Ok(ret),
+        }
+    }
+}

--- a/src/guest/call/maybe_alloc.rs
+++ b/src/guest/call/maybe_alloc.rs
@@ -5,6 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Commit, Committer};
 use crate::Result;
 
+/// A call, which *may* result in allocation within the block.
 pub trait MaybeAlloc<'a, K, T>
 where
     K: kind::Kind,

--- a/src/guest/call/mod.rs
+++ b/src/guest/call/mod.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Calls executable by [`Handler::execute`](super::Handler::execute) and utilities to operate upon
+//! them.
+
 pub mod alloc;
 pub mod enarxcall;
 pub mod gdbcall;
@@ -16,6 +19,7 @@ pub use stub::*;
 use crate::guest::alloc::{Allocator, Collect, Commit};
 use crate::Result;
 
+/// Call kinds.
 pub mod kind {
     use super::alloc;
 

--- a/src/guest/call/mod.rs
+++ b/src/guest/call/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod alloc;
+pub mod enarxcall;
 pub mod gdbcall;
 pub mod syscall;
 pub mod types;

--- a/src/guest/call/stub.rs
+++ b/src/guest/call/stub.rs
@@ -5,6 +5,7 @@ use crate::Result;
 
 use super::{kind, Call};
 
+/// A call, which does not result in an allocation within the block.
 pub trait Stub {
     /// Call return value.
     ///

--- a/src/guest/handler.rs
+++ b/src/guest/handler.rs
@@ -509,51 +509,6 @@ pub trait Handler: Platform {
             .unwrap_or_else(|| self.attacked())
     }
 
-    // GDB calls, sorted alphabetically.
-
-    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::Connection::flush]")]
-    #[inline]
-    fn gdb_flush(&mut self) -> Result<()> {
-        self.execute(gdbcall::Flush)?
-    }
-
-    #[cfg_attr(
-        feature = "doc",
-        doc = "Executes [gdbstub::conn::Connection::on_session_start]"
-    )]
-    #[inline]
-    fn gdb_on_session_start(&mut self) -> Result<()> {
-        self.execute(gdbcall::OnSessionStart)?
-    }
-
-    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::ConnectionExt::peek]")]
-    #[inline]
-    fn gdb_peek(&mut self) -> Result<Option<u8>> {
-        self.execute(gdbcall::Peek)?
-    }
-
-    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::ConnectionExt::read]")]
-    #[inline]
-    fn gdb_read(&mut self) -> Result<u8> {
-        self.execute(gdbcall::Read)?
-    }
-
-    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::Connection::write]")]
-    #[inline]
-    fn gdb_write(&mut self, byte: u8) -> Result<()> {
-        self.execute(gdbcall::Write { byte })?
-    }
-
-    #[cfg_attr(
-        feature = "doc",
-        doc = "Executes [gdbstub::conn::Connection::write_all] and returns the amount of bytes written"
-    )]
-    #[inline]
-    fn gdb_write_all(&mut self, buf: &[u8]) -> Result<usize> {
-        self.execute(gdbcall::WriteAll { buf })?
-            .unwrap_or_else(|| self.attacked())
-    }
-
     /// Executes a supported syscall expressed as an opaque 7-word array akin to [`libc::syscall`].
     ///
     /// # Safety
@@ -804,5 +759,50 @@ pub trait Handler: Platform {
             }
             _ => Err(ENOSYS),
         }
+    }
+
+    // GDB calls, sorted alphabetically.
+
+    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::Connection::flush]")]
+    #[inline]
+    fn gdb_flush(&mut self) -> Result<()> {
+        self.execute(gdbcall::Flush)?
+    }
+
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Executes [gdbstub::conn::Connection::on_session_start]"
+    )]
+    #[inline]
+    fn gdb_on_session_start(&mut self) -> Result<()> {
+        self.execute(gdbcall::OnSessionStart)?
+    }
+
+    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::ConnectionExt::peek]")]
+    #[inline]
+    fn gdb_peek(&mut self) -> Result<Option<u8>> {
+        self.execute(gdbcall::Peek)?
+    }
+
+    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::ConnectionExt::read]")]
+    #[inline]
+    fn gdb_read(&mut self) -> Result<u8> {
+        self.execute(gdbcall::Read)?
+    }
+
+    #[cfg_attr(feature = "doc", doc = "Executes [gdbstub::conn::Connection::write]")]
+    #[inline]
+    fn gdb_write(&mut self, byte: u8) -> Result<()> {
+        self.execute(gdbcall::Write { byte })?
+    }
+
+    #[cfg_attr(
+        feature = "doc",
+        doc = "Executes [gdbstub::conn::Connection::write_all] and returns the amount of bytes written"
+    )]
+    #[inline]
+    fn gdb_write_all(&mut self, buf: &[u8]) -> Result<usize> {
+        self.execute(gdbcall::WriteAll { buf })?
+            .unwrap_or_else(|| self.attacked())
     }
 }

--- a/src/guest/handler.rs
+++ b/src/guest/handler.rs
@@ -5,6 +5,7 @@ use super::call::kind;
 use super::syscall::types::{SockaddrInput, SockaddrOutput, SockoptInput};
 use super::{enarxcall, gdbcall, syscall, Call, Platform, ThreadLocalStorage, SIGRTMAX};
 use crate::item::enarxcall::sgx;
+use crate::item::syscall::sigaction;
 use crate::{item, Result};
 use core::arch::x86_64::CpuidResult;
 use core::mem::size_of;
@@ -12,10 +13,9 @@ use core::ptr::NonNull;
 use core::slice;
 
 use libc::{
-    c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, off_t, pid_t, pollfd, sigaction,
-    sigset_t, size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT, EINVAL,
-    ENOSYS, ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
-    TIOCGWINSZ,
+    c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, off_t, pid_t, pollfd, sigset_t,
+    size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT, EINVAL, ENOSYS,
+    ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ,
 };
 
 /// Guest request handler.

--- a/src/guest/mod.rs
+++ b/src/guest/mod.rs
@@ -59,7 +59,7 @@ mod handler;
 mod platform;
 mod tls;
 
-pub use call::{gdbcall, syscall, Call};
+pub use call::{enarxcall, gdbcall, syscall, Call};
 pub use handler::*;
 pub use platform::*;
 pub use tls::*;

--- a/src/guest/tls.rs
+++ b/src/guest/tls.rs
@@ -4,6 +4,7 @@ use libc::{c_int, sigaction};
 
 pub(super) const SIGRTMAX: c_int = 64;
 
+/// Thread-local storage shared between [`Handler`](super::Handler) instances.
 pub struct ThreadLocalStorage {
     pub(super) actions: [Option<sigaction>; SIGRTMAX as _],
 }

--- a/src/guest/tls.rs
+++ b/src/guest/tls.rs
@@ -10,7 +10,7 @@ pub struct ThreadLocalStorage {
 
 impl ThreadLocalStorage {
     #[inline]
-    fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             actions: [None; SIGRTMAX as _],
         }

--- a/src/guest/tls.rs
+++ b/src/guest/tls.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use libc::{c_int, sigaction};
+use crate::item::syscall::sigaction;
+
+use libc::c_int;
 
 pub(super) const SIGRTMAX: c_int = 64;
 

--- a/src/host/enarxcall.rs
+++ b/src/host/enarxcall.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::deref_aligned;
+use crate::item::enarxcall::Number;
+use crate::{item, Result};
+
+use core::arch::asm;
+use core::arch::x86_64::CpuidResult;
+
+pub(super) unsafe fn execute(call: &mut item::Enarxcall, data: &mut [u8]) -> Result<()> {
+    match call {
+        item::Enarxcall {
+            num,
+            argv: [leaf, sub_leaf, result_offset, ..],
+            ret,
+        } if *num == Number::Cpuid as _ => {
+            let result = deref_aligned::<CpuidResult>(data, *result_offset, 1)?;
+
+            // Adapted from https://github.com/rust-lang/stdarch/blob/b4a0e07552cf90ef8f1a5b775bf70e4db94b3d63/crates/core_arch/src/x86/cpuid.rs#L51-L89
+
+            // LLVM sometimes reserves `ebx` for its internal use, we so we need to use
+            // a scratch register for it instead.
+            #[cfg(target_arch = "x86_64")]
+            asm!(
+                "movq %rbx, {0:r}",
+                "cpuid",
+                "xchgq %rbx, {0:r}",
+                lateout(reg) (*result).ebx,
+                inlateout("eax") *leaf as u32 => (*result).eax,
+                inlateout("ecx") *sub_leaf  as u32 => (*result).ecx,
+                lateout("edx") (*result).edx,
+                options(nostack, preserves_flags, att_syntax),
+            );
+            *ret = 0; // Indicate success
+        }
+
+        _ => return Err(libc::ENOSYS),
+    }
+    Ok(())
+}

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -61,7 +61,7 @@ pub fn execute<'a>(items: impl IntoIterator<Item = Item<'a>>) {
 /// Callers must ensure that pointer is correctly aligned before accessing it.
 ///
 #[inline]
-unsafe fn deref<T>(data: &mut [u8], offset: usize, len: usize) -> Result<*mut T> {
+pub unsafe fn deref<T>(data: &mut [u8], offset: usize, len: usize) -> Result<*mut T> {
     let size = len * size_of::<T>();
     if size > data.len() || data.len() - size < offset {
         Err(libc::EFAULT)
@@ -73,7 +73,7 @@ unsafe fn deref<T>(data: &mut [u8], offset: usize, len: usize) -> Result<*mut T>
 /// Validates that `data` contains `len` elements of type `T` at `offset`
 /// aligned to `align_of::<T>()` and returns a mutable pointer to the first element on success.
 #[inline]
-fn deref_aligned<T>(data: &mut [u8], offset: usize, len: usize) -> Result<*mut T> {
+pub fn deref_aligned<T>(data: &mut [u8], offset: usize, len: usize) -> Result<*mut T> {
     let ptr = unsafe { deref::<T>(data, offset, len) }?;
     if ptr.align_offset(align_of::<T>()) != 0 {
         Err(EFAULT)

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -3,6 +3,8 @@
 //! Host-specific functionality.
 
 #[cfg(not(miri))]
+mod enarxcall;
+#[cfg(not(miri))]
 mod syscall;
 
 use crate::item::Item;
@@ -28,6 +30,11 @@ impl<'a> Execute for Item<'a> {
 
             Item::Gdbcall { .. } => {}
 
+            #[cfg(not(miri))]
+            Item::Enarxcall(call, data) => {
+                let _ = enarxcall::execute(call, data);
+            }
+            #[cfg(miri)]
             Item::Enarxcall { .. } => {}
         }
     }

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -26,6 +26,8 @@ impl<'a> Execute for Item<'a> {
             Item::Syscall { .. } => {}
 
             Item::Gdbcall { .. } => {}
+
+            Item::Enarxcall { .. } => {}
         }
     }
 }

--- a/src/item/block.rs
+++ b/src/item/block.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{gdbcall, syscall, Item, Kind, LARGEST_ITEM_SIZE};
+use super::{enarxcall, gdbcall, syscall, Item, Kind, LARGEST_ITEM_SIZE};
 
 use core::convert::TryInto;
 use core::mem::{align_of, size_of};
@@ -95,6 +95,11 @@ impl<'a> From<Block<'a>> for Option<(Option<Item<'a>>, Block<'a>)> {
                     Ok(Kind::Gdbcall) => {
                         decode_item::<{ gdbcall::USIZE_COUNT }, gdbcall::Payload>(*size, tail)
                             .map(|((call, data), tail)| (Some(Item::Gdbcall(call, data)), tail))
+                    }
+
+                    Ok(Kind::Enarxcall) => {
+                        decode_item::<{ enarxcall::USIZE_COUNT }, enarxcall::Payload>(*size, tail)
+                            .map(|((call, data), tail)| (Some(Item::Enarxcall(call, data)), tail))
                     }
 
                     Err(_) => Some((None, tail.split_at_mut(*size / size_of::<usize>()).1.into())),

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::mem::size_of;
+
+/// `get_attestation` syscall number used by the shim.
+///
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
+#[allow(dead_code)]
+pub const SYS_GETATT: i64 = 0xEA01;
+
+/// Payload of an [`Item`](super::Item) of [`Kind::Enarxcall`](super::Kind::Enarxcall).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C, align(8))]
+pub struct Payload {
+    pub num: Number,
+    pub argv: [usize; 4],
+    pub ret: usize,
+}
+
+pub(crate) const USIZE_COUNT: usize = size_of::<Payload>() / size_of::<usize>();
+
+impl From<&mut [usize; USIZE_COUNT]> for &mut Payload {
+    #[inline]
+    fn from(buf: &mut [usize; USIZE_COUNT]) -> Self {
+        debug_assert_eq!(size_of::<Payload>(), USIZE_COUNT * size_of::<usize>());
+        unsafe { &mut *(buf as *mut _ as *mut _) }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(usize)]
+/// Number of an [`Item`](super::Item) of [`Kind::Enarxcall`](super::Kind::Enarxcall).
+pub enum Number {
+}
+
+/// `get_attestation` technology return value
+///
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
+#[allow(dead_code)]
+pub const SEV_TECH: usize = 1;
+
+/// `get_attestation` technology return value
+///
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
+#[allow(dead_code)]
+pub const SGX_TECH: usize = 2;
+
+/// Size in bytes of expected SGX Quote
+// TODO: Determine length of Quote of PCK cert type
+#[allow(dead_code)]
+pub const SGX_QUOTE_SIZE: usize = 4598;
+
+/// Size in bytes of expected SGX QE TargetInfo
+#[allow(dead_code)]
+pub const SGX_TI_SIZE: usize = 512;
+
+/// Dummy value returned when daemon to return SGX TargetInfo is
+/// not available on the system.
+#[allow(dead_code)]
+pub const SGX_DUMMY_TI: [u8; SGX_TI_SIZE] = [32u8; SGX_TI_SIZE];
+
+/// Dummy value returned when daemon to return SGX Quote is not
+/// available on the system.
+#[allow(dead_code)]
+pub const SGX_DUMMY_QUOTE: [u8; SGX_QUOTE_SIZE] = [44u8; SGX_QUOTE_SIZE];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_size() {
+        assert_eq!(size_of::<Payload>(), USIZE_COUNT * size_of::<usize>())
+    }
+}

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[macro_use]
+pub mod testaso;
+
+pub mod sgx;
+
 use core::mem::size_of;
 
 /// `get_attestation` syscall number used by the shim.

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 pub mod testaso;
 
+pub mod sev;
 pub mod sgx;
 
 use core::mem::size_of;
@@ -38,37 +39,6 @@ impl From<&mut [usize; USIZE_COUNT]> for &mut Payload {
 pub enum Number {
 }
 
-/// `get_attestation` technology return value
-///
-/// See <https://github.com/enarx/enarx-keepldr/issues/31>
-#[allow(dead_code)]
-pub const SEV_TECH: usize = 1;
-
-/// `get_attestation` technology return value
-///
-/// See <https://github.com/enarx/enarx-keepldr/issues/31>
-#[allow(dead_code)]
-pub const SGX_TECH: usize = 2;
-
-/// Size in bytes of expected SGX Quote
-// TODO: Determine length of Quote of PCK cert type
-#[allow(dead_code)]
-pub const SGX_QUOTE_SIZE: usize = 4598;
-
-/// Size in bytes of expected SGX QE TargetInfo
-#[allow(dead_code)]
-pub const SGX_TI_SIZE: usize = 512;
-
-/// Dummy value returned when daemon to return SGX TargetInfo is
-/// not available on the system.
-#[allow(dead_code)]
-pub const SGX_DUMMY_TI: [u8; SGX_TI_SIZE] = [32u8; SGX_TI_SIZE];
-
-/// Dummy value returned when daemon to return SGX Quote is not
-/// available on the system.
-#[allow(dead_code)]
-pub const SGX_DUMMY_QUOTE: [u8; SGX_QUOTE_SIZE] = [44u8; SGX_QUOTE_SIZE];
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +46,10 @@ mod tests {
     #[test]
     fn payload_size() {
         assert_eq!(size_of::<Payload>(), USIZE_COUNT * size_of::<usize>())
+    }
+
+    #[test]
+    fn tech_assignments() {
+        assert_ne!(sev::TECH, sgx::TECH);
     }
 }

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -47,6 +47,12 @@ pub enum Number {
 
     /// Cpuid instruction call number.
     Cpuid = 0x02,
+
+    /// SGX quote request call number.
+    GetSgxQuote = 0x03,
+
+    /// [SGX `TargetInfo`](sgx::TargetInfo) request call number.
+    GetSgxTargetInfo = 0x04,
 }
 
 #[cfg(test)]

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -37,6 +37,14 @@ impl From<&mut [usize; USIZE_COUNT]> for &mut Payload {
 #[repr(usize)]
 /// Number of an [`Item`](super::Item) of [`Kind::Enarxcall`](super::Kind::Enarxcall).
 pub enum Number {
+    /// MemInfo request call number.
+    MemInfo = 0x00,
+
+    /// Memory ballooning request call number.
+    BalloonMemory = 0x01,
+
+    /// Cpuid instruction call number.
+    Cpuid = 0x02,
 }
 
 #[cfg(test)]

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Enarx call item definitions
+
 #[macro_use]
 pub mod testaso;
 

--- a/src/item/enarxcall/sev.rs
+++ b/src/item/enarxcall/sev.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! SEV microarchitecture-specific constants.
+
 /// `get_attestation` technology return value
 ///
 /// See <https://github.com/enarx/enarx-keepldr/issues/31>

--- a/src/item/enarxcall/sev.rs
+++ b/src/item/enarxcall/sev.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// `get_attestation` technology return value
+///
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
+pub const TECH: usize = 1;

--- a/src/item/enarxcall/sgx.rs
+++ b/src/item/enarxcall/sgx.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains microarchitecture structures of SGX. Keep the functionality
+//! minimal and stdlib free. Use the Intel SDM struct naming conventions,
+//! instead of Rust naming conventions.
+//!
+//! Chapter 34 of the Intel SDM contains detailed documentation for these
+//! structs.
+//!
+//! Guidelines for updating this file:
+//! * Only use primitive types and arrays for the fields.
+//! * Only use u8 arrays for reserved fields and padding.
+//! * Document the structs at top-level but never the fields.
+
+#![allow(non_camel_case_types)]
+#![allow(missing_docs)]
+
+use core::arch::asm;
+
+/// Description of the local attestation source enclave contents.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct ReportPayload {
+    pub cpusvn: [u64; 2],
+    pub miscselect: u32,
+    pub cet_attributes: u8,
+    reserved1: [u8; 11],
+    pub isvextnprodid: [u64; 2],
+    pub attributes: [u64; 2],
+    pub mrenclave: [u8; 32],
+    reserved2: [u8; 32],
+    pub mrsigner: [u8; 32],
+    reserved3: [u8; 32],
+    pub configid: [u8; 64],
+    pub isvprodid: u16,
+    pub isvsvn: u16,
+    pub configsvn: u16,
+    reserved4: [u8; 42],
+    pub isvfamilyid: [u64; 2],
+    pub reportdata: [u8; 64],
+}
+
+impl Default for ReportPayload {
+    fn default() -> Self {
+        Self {
+            cpusvn: [0, 0],
+            miscselect: 0,
+            cet_attributes: 0,
+            reserved1: [0; 11],
+            isvextnprodid: [0, 0],
+            attributes: [0, 0],
+            mrenclave: [0; 32],
+            reserved2: [0; 32],
+            mrsigner: [0; 32],
+            reserved3: [0; 32],
+            configid: [0; 64],
+            isvprodid: 0,
+            isvsvn: 0,
+            configsvn: 0,
+            reserved4: [0; 42],
+            isvfamilyid: [0, 0],
+            reportdata: [0; 64],
+        }
+    }
+}
+
+/// Description of the local attestation source enclave contents with the CMAC
+/// signed with the report key. Used by the target enclave to verify the source
+/// enclave by grabbing the report key with EGETKEY and calculating CMAC.
+#[repr(C, align(512))]
+pub struct Report {
+    pub payload: ReportPayload,
+    pub keyid: [u8; 32],
+    pub mac: [u64; 2],
+    padding: [u8; 80],
+}
+
+impl Default for Report {
+    fn default() -> Self {
+        Self {
+            payload: ReportPayload::default(),
+            keyid: [0; 32],
+            mac: [0, 0],
+            padding: [0; 80],
+        }
+    }
+}
+
+/// Description of the target enclave used for the report key derivation in
+/// EREPORT.
+#[derive(Clone, Copy)]
+#[repr(C, align(512))]
+pub struct TargetInfo {
+    pub mrenclave: [u8; 32],
+    pub attributes: [u64; 2],
+    pub cet_attributes: u8,
+    reserved1: [u8; 1],
+    pub configsvn: u16,
+    pub miscselect: u32,
+    reserved2: [u8; 8],
+    pub configid: [u8; 64],
+    reserved3: [u8; 384],
+}
+
+impl Default for TargetInfo {
+    fn default() -> Self {
+        Self {
+            mrenclave: [0; 32],
+            attributes: [0, 0],
+            cet_attributes: 0,
+            reserved1: [0; 1],
+            configsvn: 0,
+            miscselect: 0,
+            reserved2: [0; 8],
+            configid: [0; 64],
+            reserved3: [0; 384],
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, align(128))]
+/// Pass information from the source enclave to the target enclave
+pub struct ReportData(pub [u8; 64]);
+
+impl Default for ReportData {
+    fn default() -> Self {
+        Self([0u8; 64])
+    }
+}
+
+impl TargetInfo {
+    pub fn enclu_ereport(&self, reportdata: &ReportData) -> Report {
+        const EREPORT: usize = 0;
+
+        // Purposely make an uninitialized memory block for the struct, as it
+        // will be initialized by the CPU as the next step.
+        let mut report = core::mem::MaybeUninit::<Report>::uninit();
+
+        // In Rust inline assembly rbx is not preserved by the compiler, even
+        // when part of the input list. It is one of the callee saved registers
+        // dictated by:
+        //
+        // https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf
+        unsafe {
+            asm!(
+                "xchg       {RBX}, rbx",
+                "enclu",
+                "mov        rbx, {RBX}",
+
+                RBX = inout(reg) self => _,
+                in("rax") EREPORT,
+                in("rcx") reportdata.0.as_ptr(),
+                in("rdx") report.as_mut_ptr(),
+            );
+        }
+
+        unsafe { report.assume_init() }
+    }
+}
+
+#[cfg(test)]
+testaso! {
+    struct ReportPayload: 8, 384 => {
+        cpusvn: 0,
+        miscselect: 16,
+        cet_attributes: 20,
+        reserved1: 21,
+        isvextnprodid: 32,
+        attributes: 48,
+        mrenclave: 64,
+        reserved2: 96,
+        mrsigner: 128,
+        reserved3: 160,
+        configid: 192,
+        isvprodid: 256,
+        isvsvn: 258,
+        configsvn: 260,
+        reserved4: 262,
+        isvfamilyid: 304,
+        reportdata: 320
+    }
+
+    struct Report: 512, 512 => {
+        payload: 0,
+        keyid: 384,
+        mac: 416,
+        padding: 432
+    }
+
+    struct TargetInfo: 512, 512 => {
+        mrenclave: 0,
+        attributes: 32,
+        cet_attributes: 48,
+        reserved1: 49,
+        configsvn: 50,
+        miscselect: 52,
+        reserved2: 56,
+        configid: 64,
+        reserved3: 128
+    }
+}

--- a/src/item/enarxcall/sgx.rs
+++ b/src/item/enarxcall/sgx.rs
@@ -106,6 +106,13 @@ impl Default for Report {
     }
 }
 
+impl AsRef<[u8; size_of::<Report>()]> for Report {
+    #[inline]
+    fn as_ref(&self) -> &[u8; size_of::<Report>()] {
+        unsafe { &*(self as *const _ as *const _) }
+    }
+}
+
 /// Description of the target enclave used for the report key derivation in
 /// EREPORT.
 #[derive(Debug, Clone, Copy)]
@@ -136,6 +143,13 @@ impl Default for TargetInfo {
             configid: [0; 64],
             reserved3: [0; 384],
         }
+    }
+}
+
+impl AsMut<[u8; size_of::<TargetInfo>()]> for TargetInfo {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8; size_of::<TargetInfo>()] {
+        unsafe { &mut *(self as *mut _ as *mut _) }
     }
 }
 

--- a/src/item/enarxcall/sgx.rs
+++ b/src/item/enarxcall/sgx.rs
@@ -15,6 +15,24 @@
 #![allow(missing_docs)]
 
 use core::arch::asm;
+use core::mem::{size_of, MaybeUninit};
+
+/// `get_attestation` technology return value
+///
+/// See <https://github.com/enarx/enarx-keepldr/issues/31>
+pub const TECH: usize = 2;
+
+/// Size in bytes of expected SGX Quote
+// TODO: Determine length of Quote of PCK cert type
+pub const QUOTE_SIZE: usize = 4598;
+
+/// Dummy value returned when daemon to return SGX TargetInfo is
+/// not available on the system.
+pub const DUMMY_TI: [u8; size_of::<TargetInfo>()] = [32u8; size_of::<TargetInfo>()];
+
+/// Dummy value returned when daemon to return SGX Quote is not
+/// available on the system.
+pub const DUMMY_QUOTE: [u8; QUOTE_SIZE] = [44u8; QUOTE_SIZE];
 
 /// Description of the local attestation source enclave contents.
 #[derive(Debug, Clone, Copy)]

--- a/src/item/enarxcall/sgx.rs
+++ b/src/item/enarxcall/sgx.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Contains microarchitecture structures of SGX. Keep the functionality
-//! minimal and stdlib free. Use the Intel SDM struct naming conventions,
-//! instead of Rust naming conventions.
+//! SGX microarchitecture-specific structures and constants.
+//!
+//! Only minimal functionality is provided by this module.
 //!
 //! Chapter 34 of the Intel SDM contains detailed documentation for these
 //! structs.

--- a/src/item/enarxcall/testaso.rs
+++ b/src/item/enarxcall/testaso.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(test)]
+
+/// This macro enables writing tests for alignment, size, and offset of fields in structs.
+/// Example usage:
+/// testaso! {
+///     struct mystruct: 8, 4096 => {
+///         f1: 0,
+///         f2: 8
+///     }
+/// }
+#[cfg(test)]
+macro_rules! testaso {
+    (@off $name:path=>$field:ident) => {
+        memoffset::offset_of!($name, $field)
+    };
+
+    ($(struct $name:path: $align:expr, $size:expr => { $($field:ident: $offset:expr),* })+) => {
+        #[cfg(test)]
+        #[test]
+        fn align() {
+            use core::mem::align_of;
+
+            $(
+                assert_eq!(
+                    align_of::<$name>(),
+                    $align,
+                    "align: {}",
+                    stringify!($name)
+                );
+            )+
+        }
+
+        #[cfg(test)]
+        #[test]
+        fn size() {
+            use core::mem::size_of;
+
+            $(
+                assert_eq!(
+                    size_of::<$name>(),
+                    $size,
+                    "size: {}",
+                    stringify!($name)
+                );
+            )+
+        }
+
+        #[cfg(test)]
+        #[test]
+        fn offsets() {
+            $(
+                $(
+                    assert_eq!(
+                        testaso!(@off $name=>$field),
+                        $offset,
+                        "offset: {}::{}",
+                        stringify!($name),
+                        stringify!($field)
+                    );
+                )*
+        )+
+        }
+    };
+}

--- a/src/item/gdbcall.rs
+++ b/src/item/gdbcall.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! GDB call item definitions
+
 use core::mem::size_of;
 
 /// Payload of an [`Item`](super::Item) of [`Kind::Gdbcall`](super::Kind::Gdbcall).

--- a/src/item/syscall.rs
+++ b/src/item/syscall.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! System call item definitions
+
 use core::mem::size_of;
 
 /// Payload of an [`Item`](super::Item) of [`Kind::Syscall`](super::Kind::Syscall).

--- a/src/item/syscall.rs
+++ b/src/item/syscall.rs
@@ -21,60 +21,6 @@ impl From<&mut [usize; USIZE_COUNT]> for &mut Payload {
     }
 }
 
-/// `get_attestation` syscall number
-///
-/// See <https://github.com/enarx/enarx-keepldr/issues/31>
-#[allow(dead_code)]
-pub const SYS_ENARX_GETATT: i64 = 0xEA01;
-
-/// Enarx syscall extension: get [`MemInfo`] from the host
-#[allow(dead_code)]
-pub const SYS_ENARX_MEM_INFO: i64 = 0xEA02;
-
-/// Enarx syscall extension: request an additional memory region
-#[allow(dead_code)]
-pub const SYS_ENARX_BALLOON_MEMORY: i64 = 0xEA03;
-
-/// Enarx syscall extension: CPUID
-#[allow(dead_code)]
-pub const SYS_ENARX_CPUID: i64 = 0xEA04;
-
-/// Enarx syscall extension: Resume an enclave after an asynchronous exit
-// Keep in sync with shim-sgx/src/start.S
-#[allow(dead_code)]
-pub const SYS_ENARX_ERESUME: i64 = -1;
-
-/// `get_attestation` technology return value
-///
-/// See <https://github.com/enarx/enarx-keepldr/issues/31>
-#[allow(dead_code)]
-pub const SEV_TECH: usize = 1;
-
-/// `get_attestation` technology return value
-///
-/// See <https://github.com/enarx/enarx-keepldr/issues/31>
-#[allow(dead_code)]
-pub const SGX_TECH: usize = 2;
-
-/// Size in bytes of expected SGX Quote
-// TODO: Determine length of Quote of PCK cert type
-#[allow(dead_code)]
-pub const SGX_QUOTE_SIZE: usize = 4598;
-
-/// Size in bytes of expected SGX QE TargetInfo
-#[allow(dead_code)]
-pub const SGX_TI_SIZE: usize = 512;
-
-/// Dummy value returned when daemon to return SGX TargetInfo is
-/// not available on the system.
-#[allow(dead_code)]
-pub const SGX_DUMMY_TI: [u8; SGX_TI_SIZE] = [32u8; SGX_TI_SIZE];
-
-/// Dummy value returned when daemon to return SGX Quote is not
-/// available on the system.
-#[allow(dead_code)]
-pub const SGX_DUMMY_QUOTE: [u8; SGX_QUOTE_SIZE] = [44u8; SGX_QUOTE_SIZE];
-
 // arch_prctl syscalls not available in the libc crate as of version 0.2.69
 /// missing in libc
 pub const ARCH_SET_GS: libc::c_int = 0x1001;
@@ -84,18 +30,6 @@ pub const ARCH_SET_FS: libc::c_int = 0x1002;
 pub const ARCH_GET_FS: libc::c_int = 0x1003;
 /// missing in libc
 pub const ARCH_GET_GS: libc::c_int = 0x1004;
-
-/// Basic information about the host memory, the shim requests
-/// from the loader via the [`SYS_ENARX_MEM_INFO`] syscall
-#[repr(C)]
-#[derive(Copy, Clone, Default, Debug)]
-pub struct MemInfo {
-    /// Number of memory slot available for ballooning
-    ///
-    /// KVM only has a limited number of memory ballooning slots, which varies by technology and kernel version.
-    /// Knowing this number helps the shim allocator to decide how much memory to allocate for each slot.
-    pub mem_slots: usize,
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/item/syscall.rs
+++ b/src/item/syscall.rs
@@ -33,6 +33,11 @@ pub const ARCH_GET_FS: libc::c_int = 0x1003;
 /// missing in libc
 pub const ARCH_GET_GS: libc::c_int = 0x1004;
 
+// [`libc::sigaction`] is not in the format used by the kernel.
+/// sigaction as expected by the kernel.
+#[allow(non_camel_case_types)] // follow `libc` conventions
+pub type sigaction = [u64; 4];
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/integration_tests/enarxcall.rs
+++ b/tests/integration_tests/enarxcall.rs
@@ -6,6 +6,7 @@ use libc::ENOSYS;
 use std::arch::x86_64::{CpuidResult, __cpuid_count};
 
 use sallyport::guest::Handler;
+use sallyport::item::enarxcall::sgx;
 
 #[test]
 fn balloon_memory() {
@@ -26,6 +27,23 @@ fn cpuid() {
         };
         assert_eq!(handler.cpuid(0, 0, &mut result), Ok(()));
         assert_eq!(result, unsafe { __cpuid_count(0, 0) })
+    })
+}
+
+#[test]
+fn get_sgx_quote() {
+    run_test(1, [0xff; 1024], move |_, handler| {
+        let report = Default::default();
+        let mut quote = [0u8; sgx::QUOTE_SIZE];
+        assert_eq!(handler.get_sgx_quote(&report, &mut quote), Err(ENOSYS));
+    })
+}
+
+#[test]
+fn get_sgx_target_info() {
+    run_test(1, [0xff; 512], move |_, handler| {
+        let mut info = Default::default();
+        assert_eq!(handler.get_sgx_target_info(&mut info), Err(ENOSYS));
     })
 }
 

--- a/tests/integration_tests/enarxcall.rs
+++ b/tests/integration_tests/enarxcall.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::run_test;
+
+use libc::ENOSYS;
+use std::arch::x86_64::{CpuidResult, __cpuid_count};
+
+use sallyport::guest::Handler;
+
+#[test]
+fn balloon_memory() {
+    run_test(1, [0xff; 16], move |_, handler| {
+        assert_eq!(handler.balloon_memory(1, 2, 0xfeed as _), Err(ENOSYS));
+    })
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn cpuid() {
+    run_test(1, [0xff; 16], move |_, handler| {
+        let mut result = CpuidResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
+        };
+        assert_eq!(handler.cpuid(0, 0, &mut result), Ok(()));
+        assert_eq!(result, unsafe { __cpuid_count(0, 0) })
+    })
+}
+
+#[test]
+fn mem_info() {
+    run_test(1, [0xff; 16], move |_, handler| {
+        assert_eq!(handler.mem_info(), Err(ENOSYS));
+    })
+}

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod enarxcall;
 pub mod syscall;
 
 use std::ffi::CStr;

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod syscall;
+
+use std::ffi::CStr;
+use std::io::Write;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::ptr::NonNull;
+use std::{slice, thread};
+
+use libc::{c_int, c_ulong, c_void, off_t, size_t, ENOSYS};
+use sallyport::guest::{Handler, Platform, ThreadLocalStorage};
+use sallyport::item::Block;
+use sallyport::{host, Result};
+
+pub struct TestHandler<const N: usize>([usize; N], ThreadLocalStorage);
+
+impl<const N: usize> Platform for TestHandler<N> {
+    fn sally(&mut self) -> Result<()> {
+        host::execute(Block::from(self.block_mut()));
+        Ok(())
+    }
+
+    fn validate<'b, T>(&self, ptr: usize) -> Result<&'b T> {
+        Ok(unsafe { &*(ptr as *const _) })
+    }
+
+    fn validate_mut<'b, T>(&self, ptr: usize) -> Result<&'b mut T> {
+        Ok(unsafe { &mut *(ptr as *mut _) })
+    }
+
+    fn validate_slice<'b, T>(&self, ptr: usize, len: usize) -> Result<&'b [T]> {
+        Ok(unsafe { slice::from_raw_parts(ptr as _, len) })
+    }
+
+    fn validate_slice_mut<'b, T>(&self, ptr: usize, len: usize) -> Result<&'b mut [T]> {
+        Ok(unsafe { slice::from_raw_parts_mut(ptr as _, len) })
+    }
+
+    fn validate_str<'b>(&self, ptr: usize) -> Result<&'b [u8]> {
+        Ok(unsafe { CStr::from_ptr(ptr as _) }.to_bytes())
+    }
+
+    fn validate_iovec_slice_mut<'a>(
+        &self,
+        iov: usize,
+        iovcnt: usize,
+    ) -> Result<&'a mut [&'a mut [u8]]> {
+        Ok(unsafe { slice::from_raw_parts_mut(iov as _, iovcnt) })
+    }
+
+    fn validate_iovec_slice<'a>(&self, iov: usize, iovcnt: usize) -> Result<&'a [&'a [u8]]> {
+        Ok(unsafe { slice::from_raw_parts(iov as _, iovcnt) })
+    }
+}
+
+impl<const N: usize> Handler for TestHandler<N> {
+    fn block(&self) -> &[usize] {
+        self.0.as_slice()
+    }
+
+    fn block_mut(&mut self) -> &mut [usize] {
+        self.0.as_mut_slice()
+    }
+
+    fn thread_local_storage(&mut self) -> &mut ThreadLocalStorage {
+        &mut self.1
+    }
+
+    fn arch_prctl(&mut self, _code: c_int, _addr: c_ulong) -> Result<()> {
+        Err(ENOSYS)
+    }
+
+    fn brk(&mut self, _addr: Option<NonNull<c_void>>) -> Result<NonNull<c_void>> {
+        Err(ENOSYS)
+    }
+
+    fn madvise(&mut self, _addr: NonNull<c_void>, _length: size_t, _advice: c_int) -> Result<()> {
+        Err(ENOSYS)
+    }
+
+    fn mmap(
+        &mut self,
+        _addr: Option<NonNull<c_void>>,
+        _length: size_t,
+        _prot: c_int,
+        _flags: c_int,
+        _fd: c_int,
+        _offset: off_t,
+    ) -> Result<NonNull<c_void>> {
+        Err(ENOSYS)
+    }
+
+    fn mprotect(&mut self, _addr: NonNull<c_void>, _len: size_t, _prot: c_int) -> Result<()> {
+        Err(ENOSYS)
+    }
+
+    fn munmap(&mut self, _addr: NonNull<c_void>, _length: size_t) -> Result<()> {
+        Err(ENOSYS)
+    }
+}
+
+pub fn run_test<const N: usize>(
+    n: usize,
+    block: [usize; N],
+    f: impl FnOnce(usize, &mut TestHandler<N>) + Sync + Send + Copy + 'static,
+) {
+    for i in 0..n {
+        thread::Builder::new()
+            .name(format!("iteration {}", i))
+            .spawn(move || {
+                f(i, &mut TestHandler(block.clone(), Default::default()));
+            })
+            .expect(&format!("couldn't spawn test iteration {} thread", i))
+            .join()
+            .expect(&format!("couldn't join test iteration {} thread", i))
+    }
+}
+
+pub fn write_tcp(addr: impl ToSocketAddrs, buf: &[u8]) {
+    assert_eq!(
+        TcpStream::connect(addr)
+            .expect("couldn't connect to address")
+            .write(buf)
+            .expect("couldn't write data"),
+        buf.len()
+    );
+}

--- a/tests/integration_tests/syscall.rs
+++ b/tests/integration_tests/syscall.rs
@@ -1,133 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{run_test, write_tcp};
+
 use libc::{
-    c_int, c_ulong, c_void, iovec, off_t, size_t, sockaddr, SYS_accept, SYS_accept4, SYS_bind,
-    SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname, SYS_listen, SYS_read,
-    SYS_readv, SYS_recvfrom, SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EBADF,
-    EBADFD, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM, O_CREAT, O_RDONLY, O_RDWR,
-    SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO,
-    STDOUT_FILENO,
+    c_int, iovec, sockaddr, SYS_accept, SYS_accept4, SYS_bind, SYS_close, SYS_fcntl, SYS_fstat,
+    SYS_getrandom, SYS_getsockname, SYS_listen, SYS_read, SYS_readv, SYS_recvfrom, SYS_setsockopt,
+    SYS_socket, SYS_write, SYS_writev, AF_INET, EBADF, EBADFD, ENOSYS, F_GETFD, F_GETFL, F_SETFD,
+    F_SETFL, GRND_RANDOM, O_CREAT, O_RDONLY, O_RDWR, SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET,
+    SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 use std::env::temp_dir;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, Write};
 use std::mem::size_of;
-use std::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
+use std::net::{TcpListener, UdpSocket};
 use std::os::unix::prelude::AsRawFd;
-use std::ptr::NonNull;
 use std::slice;
 use std::{mem, thread};
 
 use sallyport::guest::syscall::types::SockaddrOutput;
-use sallyport::guest::{syscall, Handler, Platform, ThreadLocalStorage};
-use sallyport::item::Block;
-use sallyport::{host, Result};
+use sallyport::guest::{syscall, Handler};
 use serial_test::serial;
-
-struct TestHandler<const N: usize>([usize; N], ThreadLocalStorage);
-
-impl<const N: usize> Platform for TestHandler<N> {
-    fn sally(&mut self) -> Result<()> {
-        host::execute(Block::from(self.block_mut()));
-        Ok(())
-    }
-
-    fn validate<'b, T>(&self, ptr: usize) -> Result<&'b T> {
-        Ok(unsafe { &*(ptr as *const _) })
-    }
-
-    fn validate_mut<'b, T>(&self, ptr: usize) -> Result<&'b mut T> {
-        Ok(unsafe { &mut *(ptr as *mut _) })
-    }
-
-    fn validate_slice<'b, T>(&self, ptr: usize, len: usize) -> Result<&'b [T]> {
-        Ok(unsafe { slice::from_raw_parts(ptr as _, len) })
-    }
-
-    fn validate_slice_mut<'b, T>(&self, ptr: usize, len: usize) -> Result<&'b mut [T]> {
-        Ok(unsafe { slice::from_raw_parts_mut(ptr as _, len) })
-    }
-
-    fn validate_str<'b>(&self, ptr: usize) -> Result<&'b [u8]> {
-        Ok(unsafe { CStr::from_ptr(ptr as _) }.to_bytes())
-    }
-
-    fn validate_iovec_slice_mut<'a>(
-        &self,
-        iov: usize,
-        iovcnt: usize,
-    ) -> Result<&'a mut [&'a mut [u8]]> {
-        Ok(unsafe { slice::from_raw_parts_mut(iov as _, iovcnt) })
-    }
-
-    fn validate_iovec_slice<'a>(&self, iov: usize, iovcnt: usize) -> Result<&'a [&'a [u8]]> {
-        Ok(unsafe { slice::from_raw_parts(iov as _, iovcnt) })
-    }
-}
-
-impl<const N: usize> Handler for TestHandler<N> {
-    fn block(&self) -> &[usize] {
-        self.0.as_slice()
-    }
-
-    fn block_mut(&mut self) -> &mut [usize] {
-        self.0.as_mut_slice()
-    }
-
-    fn thread_local_storage(&mut self) -> &mut ThreadLocalStorage {
-        &mut self.1
-    }
-
-    fn arch_prctl(&mut self, _code: c_int, _addr: c_ulong) -> Result<()> {
-        Err(ENOSYS)
-    }
-
-    fn brk(&mut self, _addr: Option<NonNull<c_void>>) -> Result<NonNull<c_void>> {
-        Err(ENOSYS)
-    }
-
-    fn madvise(&mut self, _addr: NonNull<c_void>, _length: size_t, _advice: c_int) -> Result<()> {
-        Err(ENOSYS)
-    }
-
-    fn mmap(
-        &mut self,
-        _addr: Option<NonNull<c_void>>,
-        _length: size_t,
-        _prot: c_int,
-        _flags: c_int,
-        _fd: c_int,
-        _offset: off_t,
-    ) -> Result<NonNull<c_void>> {
-        Err(ENOSYS)
-    }
-
-    fn mprotect(&mut self, _addr: NonNull<c_void>, _len: size_t, _prot: c_int) -> Result<()> {
-        Err(ENOSYS)
-    }
-
-    fn munmap(&mut self, _addr: NonNull<c_void>, _length: size_t) -> Result<()> {
-        Err(ENOSYS)
-    }
-}
-
-fn run_test<const N: usize>(
-    n: usize,
-    block: [usize; N],
-    f: impl FnOnce(usize, &mut TestHandler<N>) + Sync + Send + Copy + 'static,
-) {
-    for i in 0..n {
-        thread::Builder::new()
-            .name(format!("iteration {}", i))
-            .spawn(move || {
-                f(i, &mut TestHandler(block.clone(), Default::default()));
-            })
-            .expect(&format!("couldn't spawn test iteration {} thread", i))
-            .join()
-            .expect(&format!("couldn't join test iteration {} thread", i))
-    }
-}
 
 fn syscall_socket(opaque: bool, exec: &mut impl Handler) -> c_int {
     let fd = if !opaque {
@@ -164,16 +58,6 @@ fn syscall_recv(opaque: bool, exec: &mut impl Handler, fd: c_int, buf: &mut [u8]
             Ok([expected_len, 0])
         );
     }
-}
-
-fn write_tcp(addr: impl ToSocketAddrs, buf: &[u8]) {
-    assert_eq!(
-        TcpStream::connect(addr)
-            .expect("couldn't connect to address")
-            .write(buf)
-            .expect("couldn't write data"),
-        buf.len()
-    );
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,1 @@
+mod integration_tests;


### PR DESCRIPTION
~[WIP] (heavily).~
~Opening this PR for @haraldh to be able to progress and to get some feedback on the issues outlined below (also see Rocket chat)~
~`get_attestation` and GDB-specific calls were treated as syscalls from userspace~ https://github.com/enarx/sallyport/blob/2eb6ca1aec2e78896b8c49aeaf5eb9f51a3b218d/src/syscall/mod.rs#L295-L300 ~in previous minor version of the crate~
~Although GDB "mode", at least, in SGX case is entered via an invalid OPCODE~ https://github.com/enarx/enarx/blob/500c0b8feaa267b559227694c469d2b1e3b12388/internal/shim-sgx/src/handler/mod.rs#L103-L121 ~, therefore the current approach should work fine.~
~The only call, which needs a designated number that does not clash with "normal" syscalls is `get_attestation`, if I understand correctly, because that call arrives from userspace, is that correct? @haraldh~

~Is there a reason we can't handle the attestation with the same OPCODE trick as GDB and therefore avoiding assigning it a syscall number?~

Added support for Enarx-specific calls, backends are expected to implement e.g. `balloon_memory` and `mem_info` by "hooking into" the item iterator via `filter_map` on host side

~SGX-specific calls will follow shortly~

There's a lot of functionality duplicated from existing calls, we should probably file a tech debt issue to look into things like deduplicating result handling, either via shared types or macros

Closes #106 