### PR TITLE
fix(poll): poll is `InOut`

### DIFF
--- a/src/guest/call/syscall/poll.rs
+++ b/src/guest/call/syscall/poll.rs
@@ -2,7 +2,7 @@
 
 use super::super::types::Argv;
 use super::Alloc;
-use crate::guest::alloc::{Allocator, Collector, Output};
+use crate::guest::alloc::{Allocator, Collector, InOut, Output};
 use crate::Result;
 
 use libc::{c_int, c_long, pollfd};
@@ -18,12 +18,12 @@ unsafe impl<'a> Alloc<'a> for Poll<'a> {
     type Argv = Argv<3>;
     type Ret = c_int;
 
-    type Staged = Output<'a, [pollfd], &'a mut [pollfd]>;
-    type Committed = Self::Staged;
+    type Staged = InOut<'a, [pollfd], &'a mut [pollfd]>;
+    type Committed = Output<'a, [pollfd], &'a mut [pollfd]>;
     type Collected = Option<Result<c_int>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
-        let fds = Output::stage_slice(alloc, self.fds)?;
+        let fds = InOut::stage_slice(alloc, self.fds)?;
         Ok((Argv([fds.offset(), fds.len(), self.timeout as _]), fds))
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -343,6 +343,33 @@ fn getrandom() {
 
 #[test]
 #[serial]
+#[cfg_attr(miri, ignore)]
+fn poll() {
+    run_test(1, [0xff; 16], move |_, handler| {
+        let mut fds: [libc::pollfd; 3] = [
+            libc::pollfd {
+                fd: 0,
+                events: 0,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: 1,
+                events: 0,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: 2,
+                events: 0,
+                revents: 0,
+            },
+        ];
+
+        assert_eq!(handler.poll(&mut fds, 0), Ok(0));
+    });
+}
+
+#[test]
+#[serial]
 fn read() {
     run_test(2, [0xff; 16], move |i, handler| {
         const EXPECTED: &str = "read";


### PR DESCRIPTION
Also add a simple test.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
