### PR TITLE
fix(sigaction): kernel sigaction is different

### DIFF
--- a/src/guest/handler.rs
+++ b/src/guest/handler.rs
@@ -10,11 +10,13 @@ use core::ptr::NonNull;
 use core::slice;
 
 use libc::{
-    c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, off_t, pid_t, pollfd, sigaction,
-    sigset_t, size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT, EINVAL,
-    ENOSYS, ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
-    TIOCGWINSZ,
+    c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, off_t, pid_t, pollfd, sigset_t,
+    size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT, EINVAL, ENOSYS,
+    ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ,
 };
+
+#[allow(non_camel_case_types)]
+pub type sigaction = [u64; 4];
 
 /// Guest request handler.
 pub trait Handler: Platform {

--- a/src/guest/tls.rs
+++ b/src/guest/tls.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use libc::{c_int, sigaction};
+use libc::c_int;
+
+#[allow(non_camel_case_types)]
+pub type sigaction = [u64; 4];
 
 pub(super) const SIGRTMAX: c_int = 64;
 


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
