### PR TITLE
feat: add elf notes with block info

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -47,6 +47,12 @@ pub mod note {
     /// The minimum sallyport semver requires
     pub const REQUIRES: u32 = 0;
 
+    /// The sallyport block size of the shim (u64)
+    pub const BLOCK_SIZE: u32 = 0x73677820;
+
+    /// The number of sallyport blocks of the shim (u64)
+    pub const NUM_BLOCKS: u32 = 0x73677821;
+
     /// SGX ELF Notes
     pub mod sgx {
         /// The SGX enclave bits (u8; in powers of 2)


### PR DESCRIPTION
Add two elf note tags, which report about the shim's sallyport block
size and the number of blocks.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
