### PR TITLE
fix(sigaltstack): first argument can be NULL

### DIFF
--- a/src/guest/call/syscall/stub.rs
+++ b/src/guest/call/syscall/stub.rs
@@ -199,7 +199,7 @@ impl Stub for RtSigprocmask<'_> {
 }
 
 pub struct Sigaltstack<'a> {
-    pub ss: &'a stack_t,
+    pub ss: Option<&'a stack_t>,
     pub old_ss: Option<&'a mut stack_t>,
 }
 


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
