### PR TITLE
fix: separate memory validation from Handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod elf;
 pub mod guest;
 pub mod host;
 pub mod item;
+pub mod util;
 
 /// Error type used within this crate.
 pub type Error = libc::c_int;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utilities
+
+pub mod ptr;

--- a/src/util/ptr.rs
+++ b/src/util/ptr.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utility functions for pointers
+
+/// Validates that `ptr` is aligned and non-null
+///
+/// Returns `Some(ptr)`, if so and `None` if not.
+pub fn is_aligned_non_null<T>(ptr: usize) -> Option<usize> {
+    if ptr == 0 || ptr % core::mem::align_of::<T>() != 0 {
+        return None;
+    }
+    Some(ptr)
+}

--- a/tests/integration_tests/enarxcall.rs
+++ b/tests/integration_tests/enarxcall.rs
@@ -10,7 +10,7 @@ use sallyport::item::enarxcall::sgx;
 
 #[test]
 fn balloon_memory() {
-    run_test(1, [0xff; 16], move |_, handler| {
+    run_test(1, [0xff; 16], move |_, _, handler| {
         assert_eq!(handler.balloon_memory(1, 2, 0xfeed as _), Err(ENOSYS));
     })
 }
@@ -18,7 +18,7 @@ fn balloon_memory() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn cpuid() {
-    run_test(1, [0xff; 16], move |_, handler| {
+    run_test(1, [0xff; 16], move |_, _, handler| {
         let mut result = CpuidResult {
             eax: 0,
             ebx: 0,
@@ -32,7 +32,7 @@ fn cpuid() {
 
 #[test]
 fn get_sgx_quote() {
-    run_test(1, [0xff; 1024], move |_, handler| {
+    run_test(1, [0xff; 1024], move |_, _, handler| {
         let report = Default::default();
         let mut quote = [0u8; sgx::QUOTE_SIZE];
         assert_eq!(handler.get_sgx_quote(&report, &mut quote), Err(ENOSYS));
@@ -41,7 +41,7 @@ fn get_sgx_quote() {
 
 #[test]
 fn get_sgx_target_info() {
-    run_test(1, [0xff; 512], move |_, handler| {
+    run_test(1, [0xff; 512], move |_, _, handler| {
         let mut info = Default::default();
         assert_eq!(handler.get_sgx_target_info(&mut info), Err(ENOSYS));
     })
@@ -49,7 +49,7 @@ fn get_sgx_target_info() {
 
 #[test]
 fn mem_info() {
-    run_test(1, [0xff; 16], move |_, handler| {
+    run_test(1, [0xff; 16], move |_, _, handler| {
         assert_eq!(handler.mem_info(), Err(ENOSYS));
     })
 }


### PR DESCRIPTION
Previously the `validate_*` methods were giving out objects with an
unbound lifetime.

To ensure lifetimes don't outlive the real syscall, the caller of
`Handler::syscall` now has to pass a `Platform` object, which binds the
lifetimes of all objects generated by its `validate_*` methods to
itsself.

Also the `sally()` method is now part of the `Handler` trait to decouple
it from the `Platform` object, because it needs a mutable self.

The implementation of the `Platform` object has to use internal
mutablity to be able to hand out multiple mutable references.

To be feature complete, the `Platform` trait would have to have `drop`
methods for its internal bookkeeping. But doing so is a out of scope for
this project for now.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
