### PR TITLE
fix: avoid confusion with getrandom flags

### DIFF
--- a/src/guest/call/syscall/stub.rs
+++ b/src/guest/call/syscall/stub.rs
@@ -126,8 +126,7 @@ impl Stub for Getrandom<'_> {
     type Ret = Result<size_t>;
 
     fn collect(self, _: &impl Collector) -> Self::Ret {
-        let flags = self.flags & !(libc::GRND_NONBLOCK | libc::GRND_RANDOM);
-        if flags != 0 {
+        if self.flags & !(libc::GRND_NONBLOCK | libc::GRND_RANDOM) != 0 {
             return Err(libc::EINVAL);
         }
 


### PR DESCRIPTION
Remove the `flags` variable to not confuse it with `self.flags`, as it
is only needed to check for the validity of `self.flags`.

Signed-off-by: Harald Hoyer <harald@profian.com>

Related: https://github.com/enarx/sallyport/issues/116
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
