### PR TITLE
refactor: vendor libc for compiling on x86_64-unknown-none

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+on: [pull_request]
+name: build
+jobs:
+  build:
+    name: build x86_64-unknown-none
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rust-src
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -Z build-std --target x86_64-unknown-none

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,8 @@ is-it-maintained-open-issues = { repository = "enarx/sallyport" }
 [dependencies]
 gdbstub = { version = "0.6.0", default-features = false, optional = true }
 goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
-libc = { version = "0.2", features = [] }
 
 [dev-dependencies]
-libc = { version = "0.2", features = [ "extra_traits" ] }
 serial_test = "0.6"
 memoffset = "0.6.5"
 

--- a/src/guest/alloc/mod.rs
+++ b/src/guest/alloc/mod.rs
@@ -16,6 +16,7 @@ pub use output::*;
 
 pub(super) use phase_alloc::*;
 
+use crate::libc;
 use crate::Result;
 
 use core::alloc::Layout;

--- a/src/guest/alloc/phase_alloc.rs
+++ b/src/guest/alloc/phase_alloc.rs
@@ -3,12 +3,12 @@
 use super::{Allocator, Collector, Committer, InOutRef, InRef, OutRef};
 use crate::Result;
 
+use crate::libc::{EFAULT, ENOMEM, EOVERFLOW};
 use core::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
 use core::ptr::addr_of_mut;
 use core::ptr::NonNull;
-use libc::{EFAULT, ENOMEM, EOVERFLOW};
 
 pub(crate) mod phase {
     #[repr(transparent)]

--- a/src/guest/call/alloc.rs
+++ b/src/guest/call/alloc.rs
@@ -6,9 +6,9 @@ use super::Call;
 use crate::guest::alloc::{Allocator, Collect, Collector, Commit, Committer, InRef};
 use crate::{item, Result};
 
+use crate::libc::ENOMEM;
 use core::alloc::Layout;
 use core::mem::align_of;
-use libc::ENOMEM;
 
 /// Allocatable call kinds.
 pub(crate) mod kind {

--- a/src/guest/call/enarxcall/passthrough.rs
+++ b/src/guest/call/enarxcall/passthrough.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use libc::c_void;
+use crate::libc::c_void;
 
 use super::super::types::Argv;
 use super::Alloc;

--- a/src/guest/call/enarxcall/types/alloc.rs
+++ b/src/guest/call/enarxcall/types/alloc.rs
@@ -2,6 +2,7 @@
 
 use super::super::Alloc;
 use crate::guest::alloc::{Collect, Collector, Commit, Committer, InOutRef, InRef, Input, OutRef};
+use crate::libc;
 use crate::Result;
 
 /// Staged Enarx call, which holds allocated reference to Enarx call item within the block and [opaque staged value](Alloc::Staged).

--- a/src/guest/call/enarxcall/types/result.rs
+++ b/src/guest/call/enarxcall/types/result.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::libc::c_int;
 use core::marker::PhantomData;
-use libc::c_int;
 
 pub const MAX_ERRNO: c_int = 4096;
 pub const ERRNO_START: usize = usize::MAX - MAX_ERRNO as usize;

--- a/src/guest/call/gdbcall/types/alloc.rs
+++ b/src/guest/call/gdbcall/types/alloc.rs
@@ -2,6 +2,7 @@
 
 use super::super::Alloc;
 use crate::guest::alloc::{Collect, Collector, Commit, Committer, InOutRef, InRef, Input, OutRef};
+use crate::libc;
 use crate::Result;
 
 /// Staged GDB call, which holds allocated reference to GDB call item within the block and [opaque staged value](Alloc::Staged).

--- a/src/guest/call/gdbcall/types/result.rs
+++ b/src/guest/call/gdbcall/types/result.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::libc::{c_int, EOVERFLOW};
 use core::marker::PhantomData;
-use libc::{c_int, EOVERFLOW};
 
 use crate::NULL;
 

--- a/src/guest/call/syscall/accept.rs
+++ b/src/guest/call/syscall/accept.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
 use crate::{Result, NULL};
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Accept<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/accept4.rs
+++ b/src/guest/call/syscall/accept4.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
 use crate::{Result, NULL};
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Accept4<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/alloc.rs
+++ b/src/guest/call/syscall/alloc.rs
@@ -5,7 +5,7 @@ use super::types::{self, CommittedAlloc, StagedAlloc};
 use crate::guest::alloc::{Allocator, Collector, Commit};
 use crate::Result;
 
-use libc::c_long;
+use crate::libc::c_long;
 
 /// A generic syscall, which can be allocated within the block.
 ///
@@ -22,7 +22,7 @@ use libc::c_long;
 /// use sallyport::guest::syscall::Alloc;
 /// use sallyport::Result;
 /// #
-/// # use libc::{c_int, c_long, size_t};
+/// # use sallyport::libc::{self, c_int, c_long, size_t};
 ///
 /// pub struct Read<'a> {
 ///    pub fd: c_int,

--- a/src/guest/call/syscall/bind.rs
+++ b/src/guest/call/syscall/bind.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Stage};
 use crate::Result;
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Bind<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/clock_gettime.rs
+++ b/src/guest/call/syscall/clock_gettime.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Output};
 use crate::Result;
 
-use libc::{c_long, clockid_t, timespec};
+use crate::libc::{self, c_long, clockid_t, timespec};
 
 pub struct ClockGettime<'a> {
     pub clockid: clockid_t,

--- a/src/guest/call/syscall/connect.rs
+++ b/src/guest/call/syscall/connect.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input, Stage};
 use crate::Result;
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Connect<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/epoll_ctl.rs
+++ b/src/guest/call/syscall/epoll_ctl.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;
 
-use libc::{c_int, c_long, epoll_event};
+use crate::libc::{self, c_int, c_long, epoll_event};
 
 pub struct EpollCtl<'a> {
     pub epfd: c_int,

--- a/src/guest/call/syscall/epoll_pwait.rs
+++ b/src/guest/call/syscall/epoll_pwait.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Input, Output};
 use crate::Result;
 
-use libc::{c_int, c_long, epoll_event, sigset_t};
+use crate::libc::{self, c_int, c_long, epoll_event, sigset_t};
 
 pub struct EpollPwait<'a> {
     pub epfd: c_int,

--- a/src/guest/call/syscall/epoll_wait.rs
+++ b/src/guest/call/syscall/epoll_wait.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;
 
-use libc::{c_int, c_long, epoll_event};
+use crate::libc::{self, c_int, c_long, epoll_event};
 
 pub struct EpollWait<'a> {
     pub epfd: c_int,

--- a/src/guest/call/syscall/fcntl.rs
+++ b/src/guest/call/syscall/fcntl.rs
@@ -6,9 +6,9 @@ use super::super::{MaybeAlloc, UnstagedMaybeAlloc};
 use super::PassthroughAlloc;
 use crate::Result;
 
-use libc::{
-    c_int, c_long, EBADFD, EINVAL, F_GETFD, F_GETFL, F_SETFD, F_SETFL, O_APPEND, O_RDWR, O_WRONLY,
-    STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+use crate::libc::{
+    self, c_int, c_long, EBADFD, EINVAL, F_GETFD, F_GETFL, F_SETFD, F_SETFL, O_APPEND, O_RDWR,
+    O_WRONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 
 pub struct Fcntl {

--- a/src/guest/call/syscall/getsockname.rs
+++ b/src/guest/call/syscall/getsockname.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
 use crate::Result;
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Getsockname<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/ioctl.rs
+++ b/src/guest/call/syscall/ioctl.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, InOut, Output};
 use crate::{Result, NULL};
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Ioctl<'a> {
     pub fd: c_int,

--- a/src/guest/call/syscall/nanosleep.rs
+++ b/src/guest/call/syscall/nanosleep.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Commit, Committer, InOut, Input, Output};
 use crate::{Result, NULL};
 
-use libc::{c_long, timespec, EINTR};
+use crate::libc::{self, c_long, timespec, EINTR};
 
 pub struct Nanosleep<'a> {
     pub req: &'a timespec,

--- a/src/guest/call/syscall/open.rs
+++ b/src/guest/call/syscall/open.rs
@@ -7,7 +7,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;
 
-use libc::{c_int, c_long, mode_t, EACCES, O_CLOEXEC, O_RDONLY};
+use crate::libc::{self, c_int, c_long, mode_t, EACCES, O_CLOEXEC, O_RDONLY};
 
 pub struct Open<'a> {
     pub pathname: &'a [u8],

--- a/src/guest/call/syscall/passthrough.rs
+++ b/src/guest/call/syscall/passthrough.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector};
 use crate::Result;
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 /// Trait implemented by allocatable syscalls, which are passed through directly to the host and do
 /// not require custom handling logic.
@@ -21,7 +21,7 @@ use libc::{c_int, c_long};
 /// use sallyport::guest::syscall::PassthroughAlloc;
 /// use sallyport::Result;
 /// #
-/// # use libc::{c_int, c_long};
+/// # use sallyport::libc::{self, c_int, c_long};
 ///
 /// pub struct Exit {
 ///     pub status: c_int,

--- a/src/guest/call/syscall/poll.rs
+++ b/src/guest/call/syscall/poll.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, InOut, Output};
 use crate::Result;
 
-use libc::{c_int, c_long, pollfd};
+use crate::libc::{self, c_int, c_long, pollfd};
 
 pub struct Poll<'a> {
     pub fds: &'a mut [pollfd],

--- a/src/guest/call/syscall/read.rs
+++ b/src/guest/call/syscall/read.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Read<'a> {
     pub fd: c_int,

--- a/src/guest/call/syscall/readv.rs
+++ b/src/guest/call/syscall/readv.rs
@@ -5,7 +5,7 @@ use super::{iov_len, Alloc};
 use crate::guest::alloc::{Allocator, Collector, CommitPassthrough, OutRef};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Readv<T> {
     pub fd: c_int,

--- a/src/guest/call/syscall/recv.rs
+++ b/src/guest/call/syscall/recv.rs
@@ -5,7 +5,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Recv<'a> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/recvfrom.rs
+++ b/src/guest/call/syscall/recvfrom.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Output, Stage};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Recvfrom<'a, T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/send.rs
+++ b/src/guest/call/syscall/send.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Send<'a> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/sendto.rs
+++ b/src/guest/call/syscall/sendto.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Input, Stage};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Sendto<'a, T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/setsockopt.rs
+++ b/src/guest/call/syscall/setsockopt.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Stage};
 use crate::{Result, NULL};
 
-use libc::{c_int, c_long};
+use crate::libc::{self, c_int, c_long};
 
 pub struct Setsockopt<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/stub.rs
+++ b/src/guest/call/syscall/stub.rs
@@ -4,11 +4,11 @@ use super::super::Stub;
 use crate::guest::alloc::Collector;
 use crate::Result;
 
-use core::mem;
-use libc::{
-    c_char, c_int, c_uint, gid_t, pid_t, sigset_t, size_t, stack_t, stat, uid_t, utsname, EBADFD,
-    EINVAL, ENOENT, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, S_IFIFO,
+use crate::libc::{
+    self, c_char, c_int, c_uint, gid_t, pid_t, sigset_t, size_t, stack_t, stat, uid_t, utsname,
+    EBADFD, EINVAL, ENOENT, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, S_IFIFO,
 };
+use core::mem;
 
 /// Fake GID returned by enarx.
 pub const FAKE_GID: gid_t = 1000;

--- a/src/guest/call/syscall/tests.rs
+++ b/src/guest/call/syscall/tests.rs
@@ -8,8 +8,8 @@ use crate::guest::Call;
 use crate::item::{self, syscall};
 use crate::NULL;
 
+use crate::libc::{self, socklen_t, AF_INET};
 use core::mem::size_of;
-use libc::{socklen_t, AF_INET};
 
 fn assert_call<'a, K: kind::Kind, T: Call<'a, K>, const N: usize>(
     call: T,

--- a/src/guest/call/syscall/types/alloc.rs
+++ b/src/guest/call/syscall/types/alloc.rs
@@ -2,6 +2,7 @@
 
 use super::super::Alloc;
 use crate::guest::alloc::{Collect, Collector, Commit, Committer, InOutRef, InRef, Input, OutRef};
+use crate::libc;
 use crate::Result;
 
 /// Staged syscall, which holds allocated reference to syscall item within the block and [opaque staged value](Alloc::Staged).

--- a/src/guest/call/syscall/types/bytes.rs
+++ b/src/guest/call/syscall/types/bytes.rs
@@ -2,7 +2,7 @@
 
 use crate::guest::alloc::{Commit, Committer, Input};
 
-use libc::size_t;
+use crate::libc::size_t;
 
 pub struct StagedBytesInput<'a>(pub Input<'a, [u8], &'a [u8]>);
 

--- a/src/guest/call/syscall/types/result/linux/x86_64.rs
+++ b/src/guest/call/syscall/types/result/linux/x86_64.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::libc::{c_int, EOVERFLOW};
 use core::marker::PhantomData;
-use libc::{c_int, EOVERFLOW};
 
 pub const MAX_ERRNO: c_int = 4096;
 pub const ERRNO_START: usize = usize::MAX - MAX_ERRNO as usize;
@@ -65,6 +65,7 @@ impl From<Result<isize>> for crate::Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::libc;
 
     #[test]
     fn result() {

--- a/src/guest/call/syscall/types/result/mod.rs
+++ b/src/guest/call/syscall/types/result/mod.rs
@@ -2,8 +2,6 @@
 
 //! Platform-specific syscall reply parsing functionality.
 
-#[cfg(target_os = "linux")]
 mod linux;
 
-#[cfg(target_os = "linux")]
 pub use linux::*;

--- a/src/guest/call/syscall/types/sockaddr.rs
+++ b/src/guest/call/syscall/types/sockaddr.rs
@@ -5,10 +5,10 @@ use crate::guest::alloc::{
 };
 use crate::Result;
 
+use crate::libc::{sockaddr_in, sockaddr_in6, sockaddr_storage, sockaddr_un, socklen_t, EOVERFLOW};
 use core::alloc::Layout;
 use core::mem::{align_of, size_of};
 use core::slice;
-use libc::{sockaddr_in, sockaddr_in6, sockaddr_storage, sockaddr_un, socklen_t, EOVERFLOW};
 
 pub struct SockaddrInput<'a>(pub &'a [u8]);
 

--- a/src/guest/call/syscall/types/sockopt.rs
+++ b/src/guest/call/syscall/types/sockopt.rs
@@ -3,10 +3,10 @@
 use crate::guest::alloc::{Allocator, Input, Stage};
 use crate::Result;
 
+use crate::libc::EOVERFLOW;
 use core::alloc::Layout;
 use core::mem::{align_of, size_of};
 use core::slice;
-use libc::EOVERFLOW;
 
 pub struct SockoptInput<'a>(pub &'a [u8]);
 

--- a/src/guest/call/syscall/write.rs
+++ b/src/guest/call/syscall/write.rs
@@ -6,7 +6,7 @@ use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Write<'a> {
     pub fd: c_int,

--- a/src/guest/call/syscall/writev.rs
+++ b/src/guest/call/syscall/writev.rs
@@ -5,7 +5,7 @@ use super::{iov_len, Alloc};
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, InRef};
 use crate::Result;
 
-use libc::{c_int, c_long, size_t};
+use crate::libc::{self, c_int, c_long, size_t};
 
 pub struct Writev<T> {
     pub fd: c_int,

--- a/src/guest/handler.rs
+++ b/src/guest/handler.rs
@@ -12,10 +12,10 @@ use core::mem::size_of;
 use core::ptr::NonNull;
 use core::slice;
 
-use libc::{
-    c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, mode_t, off_t, pid_t, pollfd,
-    sigset_t, size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT, EINVAL,
-    ENOSYS, ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+use crate::libc::{
+    self, c_int, c_uint, c_ulong, c_void, clockid_t, epoll_event, gid_t, mode_t, off_t, pid_t,
+    pollfd, sigset_t, size_t, stack_t, stat, timespec, uid_t, utsname, Ioctl, EBADFD, EFAULT,
+    EINVAL, ENOSYS, ENOTSUP, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
     TIOCGWINSZ,
 };
 

--- a/src/guest/platform.rs
+++ b/src/guest/platform.rs
@@ -3,7 +3,7 @@
 use super::syscall::types::SockaddrOutput;
 use core::slice;
 
-use libc::{c_int, EINVAL};
+use crate::libc::{self, c_int, EINVAL};
 
 /// Platform-specific functionality.
 pub trait Platform {

--- a/src/guest/tls.rs
+++ b/src/guest/tls.rs
@@ -2,7 +2,7 @@
 
 use crate::item::syscall::sigaction;
 
-use libc::c_int;
+use crate::libc::c_int;
 
 pub(super) const SIGRTMAX: c_int = 64;
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -10,9 +10,9 @@ mod syscall;
 use crate::item::Item;
 use crate::Result;
 
+use crate::libc::{EFAULT, EOVERFLOW};
 use core::mem::{align_of, size_of};
 use core::ptr::slice_from_raw_parts_mut;
-use libc::{EFAULT, EOVERFLOW};
 
 pub(super) trait Execute {
     unsafe fn execute(self) -> Result<()>;
@@ -104,7 +104,7 @@ mod tests {
     use crate::item::{gdbcall, Gdbcall, Syscall};
     use crate::NULL;
 
-    use libc::*;
+    use crate::libc::*;
     use std::fmt::Debug;
 
     struct DerefTestCase<T> {

--- a/src/host/syscall.rs
+++ b/src/host/syscall.rs
@@ -3,10 +3,12 @@
 use super::{deref, deref_aligned};
 use crate::{item, Result, NULL};
 
+use crate::libc::{
+    self, c_long, epoll_event, pollfd, sigset_t, sockaddr_storage, socklen_t, timespec, EFAULT,
+};
 use core::arch::asm;
 use core::mem::align_of;
 use core::ptr::{null, null_mut};
-use libc::{c_long, epoll_event, pollfd, sigset_t, sockaddr_storage, socklen_t, timespec, EFAULT};
 
 trait Execute {
     unsafe fn execute(self);

--- a/src/item/block.rs
+++ b/src/item/block.rs
@@ -148,6 +148,7 @@ impl<'a> Iterator for BlockIterator<'a> {
 mod tests {
     use super::super::HEADER_USIZE_COUNT;
     use super::*;
+    use crate::libc;
 
     #[test]
     fn block_size_hint() {

--- a/src/item/mod.rs
+++ b/src/item/mod.rs
@@ -14,9 +14,9 @@ pub use syscall::Payload as Syscall;
 
 use crate::Error;
 
+use crate::libc::EINVAL;
 use core::convert::{TryFrom, TryInto};
 use core::mem::size_of;
-use libc::EINVAL;
 
 /// The maximum size of a UDP packet
 ///

--- a/src/item/syscall.rs
+++ b/src/item/syscall.rs
@@ -2,6 +2,7 @@
 
 //! System call item definitions
 
+use crate::libc;
 use core::mem::size_of;
 
 /// Payload of an [`Item`](super::Item) of [`Kind::Syscall`](super::Kind::Syscall).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@
 #![deny(clippy::all)]
 // TODO: Enable https://github.com/enarx/sallyport/issues/32
 //#![deny(missing_docs)]
+#![feature(core_ffi_c)]
+#![feature(c_size_t)]
 #![feature(nonnull_slice_from_raw_parts)]
 #![feature(slice_ptr_len)]
 
@@ -93,10 +95,11 @@ pub mod elf;
 pub mod guest;
 pub mod host;
 pub mod item;
+pub mod libc;
 pub mod util;
 
 /// Error type used within this crate.
-pub type Error = libc::c_int;
+pub type Error = crate::libc::c_int;
 
 /// Result type returned by functionality exposed by this crate.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// We cannot use the libc crate directly.
+// This is because the sallyport crate is a dependency of the enarx shims,
+// which support the x86_64-unknown-none target,
+// and the libc crate doesn't contain the proper symbols when compiled for that target
+// (which is correct, as the "none" in our target triple's OS field indicates).
+// Ideally we would not need to maintain these definitions ourselves;
+// instead, the ideal solution would be for the official libc crate to be split
+// into platform-specific crates, with the libc crate being a facade,
+// and we could then depend on the Linux-specific crate directly.
+
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
+pub type c_char = core::ffi::c_char;
+pub type c_int = core::ffi::c_int;
+pub type c_long = core::ffi::c_long;
+pub type c_short = core::ffi::c_short;
+pub type c_uint = core::ffi::c_uint;
+pub type c_ulong = core::ffi::c_ulong;
+pub type c_void = core::ffi::c_void;
+pub type size_t = core::ffi::c_size_t;
+
+pub type blkcnt_t = i64;
+pub type blksize_t = i64;
+pub type clockid_t = i32;
+pub type dev_t = u64;
+pub type gid_t = u32;
+pub type in_addr_t = u32;
+pub type in_port_t = u16;
+pub type ino_t = u64;
+pub type mode_t = u32;
+pub type nlink_t = u64;
+pub type off_t = i64;
+pub type pid_t = i32;
+pub type sa_family_t = u16;
+pub type socklen_t = u32;
+pub type suseconds_t = i64;
+pub type time_t = i64;
+pub type uid_t = u32;
+pub type Ioctl = i32;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct epoll_event {
+    pub events: u32,
+    pub u64: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct iovec {
+    pub iov_base: *mut c_void,
+    pub iov_len: size_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct in_addr {
+    pub s_addr: in_addr_t,
+}
+
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct in6_addr {
+    pub s6_addr: [u8; 16],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct pollfd {
+    pub fd: c_int,
+    pub events: c_short,
+    pub revents: c_short,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct sigset_t {
+    __val: [c_ulong; 16],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct sockaddr {
+    pub sa_family: sa_family_t,
+    pub sa_data: [c_char; 14],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [u8; 8],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct sockaddr_storage {
+    pub ss_family: sa_family_t,
+    __ss_align: size_t,
+    __ss_pad2: [u8; 128 - 2 * 8],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct sockaddr_un {
+    pub sun_family: sa_family_t,
+    pub sun_path: [c_char; 108],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct stack_t {
+    pub ss_sp: *mut c_void,
+    pub ss_flags: c_int,
+    pub ss_size: size_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct stat {
+    pub st_dev: dev_t,
+    pub st_ino: ino_t,
+    pub st_nlink: nlink_t,
+    pub st_mode: mode_t,
+    pub st_uid: uid_t,
+    pub st_gid: gid_t,
+    __pad0: c_int,
+    pub st_rdev: dev_t,
+    pub st_size: off_t,
+    pub st_blksize: blksize_t,
+    pub st_blocks: blkcnt_t,
+    pub st_atime: time_t,
+    pub st_atime_nsec: c_long,
+    pub st_mtime: time_t,
+    pub st_mtime_nsec: c_long,
+    pub st_ctime: time_t,
+    pub st_ctime_nsec: c_long,
+    __unused: [c_long; 3],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct timespec {
+    pub tv_sec: time_t,
+    pub tv_nsec: c_long,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct timeval {
+    pub tv_sec: time_t,
+    pub tv_usec: suseconds_t,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct utsname {
+    pub sysname: [c_char; 65],
+    pub nodename: [c_char; 65],
+    pub release: [c_char; 65],
+    pub version: [c_char; 65],
+    pub machine: [c_char; 65],
+    pub domainname: [c_char; 65],
+}
+
+extern "C" {
+    pub fn __errno_location() -> *mut c_int;
+    pub fn close(fd: c_int) -> c_int;
+    pub fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;
+    pub fn open(path: *const c_char, oflag: c_int, ...) -> c_int;
+    pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
+}
+
+pub const AF_INET: c_int = 2;
+pub const EACCES: c_int = 13;
+pub const EAGAIN: c_int = 11;
+pub const EBADF: c_int = 9;
+pub const EBADFD: c_int = 77;
+pub const EFAULT: c_int = 14;
+pub const EINTR: c_int = 4;
+pub const EINVAL: c_int = 22;
+pub const ENOENT: c_int = 2;
+pub const ENOMEM: c_int = 12;
+pub const ENOSYS: c_int = 38;
+pub const ENOTSUP: c_int = 95;
+pub const ENOTTY: c_int = 25;
+pub const EOVERFLOW: c_int = 75;
+pub const EPERM: c_int = 1;
+pub const F_GETFD: c_int = 1;
+pub const F_GETFL: c_int = 3;
+pub const F_SETFD: c_int = 2;
+pub const F_SETFL: c_int = 4;
+pub const FIONBIO: Ioctl = 0x5421;
+pub const FIONREAD: Ioctl = 0x541B;
+pub const GRND_NONBLOCK: c_uint = 1;
+pub const GRND_RANDOM: c_uint = 2;
+pub const MSG_NOSIGNAL: c_int = 16384;
+pub const O_APPEND: c_int = 1024;
+pub const O_CLOEXEC: c_int = 0x80000;
+pub const O_CREAT: c_int = 64;
+pub const O_RDONLY: c_int = 0;
+pub const O_RDWR: c_int = 2;
+pub const O_WRONLY: c_int = 1;
+pub const S_IFIFO: mode_t = 4096;
+pub const SOCK_CLOEXEC: c_int = O_CLOEXEC;
+pub const SOCK_STREAM: c_int = 1;
+pub const SOL_SOCKET: c_int = 1;
+pub const SO_RCVTIMEO: c_int = 20;
+pub const SO_REUSEADDR: c_int = 2;
+pub const STDERR_FILENO: c_int = 2;
+pub const STDIN_FILENO: c_int = 0;
+pub const STDOUT_FILENO: c_int = 1;
+pub const SYS_accept: c_long = 43;
+pub const SYS_accept4: c_long = 288;
+pub const SYS_arch_prctl: c_long = 158;
+pub const SYS_bind: c_long = 49;
+pub const SYS_brk: c_long = 12;
+pub const SYS_clock_gettime: c_long = 228;
+pub const SYS_close: c_long = 3;
+pub const SYS_connect: c_long = 42;
+pub const SYS_dup: c_long = 32;
+pub const SYS_dup2: c_long = 33;
+pub const SYS_dup3: c_long = 292;
+pub const SYS_epoll_create1: c_long = 291;
+pub const SYS_epoll_ctl: c_long = 233;
+pub const SYS_epoll_pwait: c_long = 281;
+pub const SYS_epoll_wait: c_long = 232;
+pub const SYS_eventfd2: c_long = 290;
+pub const SYS_exit: c_long = 60;
+pub const SYS_exit_group: c_long = 231;
+pub const SYS_fcntl: c_long = 72;
+pub const SYS_fstat: c_long = 5;
+pub const SYS_getegid: c_long = 108;
+pub const SYS_geteuid: c_long = 107;
+pub const SYS_getgid: c_long = 104;
+pub const SYS_getpid: c_long = 39;
+pub const SYS_getuid: c_long = 102;
+pub const SYS_getrandom: c_long = 318;
+pub const SYS_getsockname: c_long = 51;
+pub const SYS_ioctl: c_long = 16;
+pub const SYS_listen: c_long = 50;
+pub const SYS_madvise: c_long = 28;
+pub const SYS_mmap: c_long = 9;
+pub const SYS_mprotect: c_long = 10;
+pub const SYS_munmap: c_long = 11;
+pub const SYS_nanosleep: c_long = 35;
+pub const SYS_open: c_long = 2;
+pub const SYS_poll: c_long = 7;
+pub const SYS_read: c_long = 0;
+pub const SYS_readlink: c_long = 89;
+pub const SYS_readv: c_long = 19;
+pub const SYS_recvfrom: c_long = 45;
+pub const SYS_rt_sigaction: c_long = 13;
+pub const SYS_rt_sigprocmask: c_long = 14;
+pub const SYS_set_tid_address: c_long = 218;
+pub const SYS_sendto: c_long = 44;
+pub const SYS_setsockopt: c_long = 54;
+pub const SYS_sigaltstack: c_long = 131;
+pub const SYS_socket: c_long = 41;
+pub const SYS_sync: c_long = 162;
+pub const SYS_uname: c_long = 63;
+pub const SYS_write: c_long = 1;
+pub const SYS_writev: c_long = 20;
+pub const TIOCGWINSZ: Ioctl = 0x5413;

--- a/tests/integration_tests/enarxcall.rs
+++ b/tests/integration_tests/enarxcall.rs
@@ -2,7 +2,7 @@
 
 use super::run_test;
 
-use libc::ENOSYS;
+use sallyport::libc::ENOSYS;
 use std::arch::x86_64::{CpuidResult, __cpuid_count};
 
 use sallyport::guest::Handler;

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -9,9 +9,9 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::ptr::NonNull;
 use std::thread;
 
-use libc::{c_int, c_ulong, c_void, off_t, size_t, EINVAL, ENOSYS};
 use sallyport::guest::{Handler, Platform, ThreadLocalStorage};
 use sallyport::item::Block;
+use sallyport::libc::{c_int, c_ulong, c_void, off_t, size_t, EINVAL, ENOSYS};
 use sallyport::util::ptr;
 use sallyport::{host, Result};
 

--- a/tests/integration_tests/syscall.rs
+++ b/tests/integration_tests/syscall.rs
@@ -2,8 +2,8 @@
 
 use super::{run_test, write_tcp};
 
-use libc::{
-    c_int, in_addr, iovec, sockaddr, sockaddr_in, timespec, timeval, SYS_accept, SYS_accept4,
+use sallyport::libc::{
+    self, c_int, in_addr, iovec, sockaddr, sockaddr_in, timespec, timeval, SYS_accept, SYS_accept4,
     SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname, SYS_listen,
     SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv, SYS_recvfrom, SYS_sendto,
     SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES, EBADF, EBADFD, EINVAL,


### PR DESCRIPTION
The libc crate naturally doesn't expose any Linux-specific items when compiling for the x86_64-unknown-none target, but we need them anyway, so in order to allow compiling for that target we provide our own definitions.

If we ever expand to supporting other platforms we can reintroduce libc with cfg workarounds. Furthermore, someday the libc crate might be split into multiple platform-specific crates, at which point we may be able to get rid of the definitions here and rely on those crates directly.

Closes https://github.com/enarx/sallyport/issues/110