### PR TITLE
feat: add get_sgx_quote_size() enarx call

### DIFF
--- a/src/guest/call/enarxcall/passthrough.rs
+++ b/src/guest/call/enarxcall/passthrough.rs
@@ -70,6 +70,21 @@ impl PassthroughAlloc for BalloonMemory {
     }
 }
 
+/// Get the size of the SGX Quote
+#[repr(transparent)]
+pub struct GetSgxQuoteSize;
+
+impl PassthroughAlloc for GetSgxQuoteSize {
+    const NUM: Number = Number::GetSgxQuoteSize;
+
+    type Argv = Argv<0>;
+    type Ret = usize;
+
+    fn stage(self) -> Self::Argv {
+        Argv([])
+    }
+}
+
 /// Get number of memory slots available for ballooning from the host.
 #[repr(transparent)]
 pub struct MemInfo;

--- a/src/guest/handler.rs
+++ b/src/guest/handler.rs
@@ -915,6 +915,12 @@ pub trait Handler {
             .unwrap_or_else(|| self.attacked())
     }
 
+    /// Requests the SGX quote size from the host.
+    #[inline]
+    fn get_sgx_quote_size(&mut self) -> Result<usize> {
+        self.execute(enarxcall::GetSgxQuoteSize)?
+    }
+
     /// Requests [SGX `TargetInfo`](sgx::TargetInfo) from the host.
     #[inline]
     fn get_sgx_target_info(&mut self, info: &mut sgx::TargetInfo) -> Result<()> {

--- a/src/item/enarxcall/mod.rs
+++ b/src/item/enarxcall/mod.rs
@@ -53,6 +53,9 @@ pub enum Number {
 
     /// [SGX `TargetInfo`](sgx::TargetInfo) request call number.
     GetSgxTargetInfo = 0x04,
+
+    /// SGX quote size request call number.
+    GetSgxQuoteSize = 0x05,
 }
 
 #[cfg(test)]

--- a/src/item/enarxcall/sgx.rs
+++ b/src/item/enarxcall/sgx.rs
@@ -22,18 +22,6 @@ use core::mem::{size_of, MaybeUninit};
 /// See <https://github.com/enarx/enarx-keepldr/issues/31>
 pub const TECH: usize = 2;
 
-/// Size in bytes of expected SGX Quote
-// TODO: Determine length of Quote of PCK cert type
-pub const QUOTE_SIZE: usize = 4598;
-
-/// Dummy value returned when daemon to return SGX TargetInfo is
-/// not available on the system.
-pub const DUMMY_TI: [u8; size_of::<TargetInfo>()] = [32u8; size_of::<TargetInfo>()];
-
-/// Dummy value returned when daemon to return SGX Quote is not
-/// available on the system.
-pub const DUMMY_QUOTE: [u8; QUOTE_SIZE] = [44u8; QUOTE_SIZE];
-
 /// Description of the local attestation source enclave contents.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]

--- a/tests/integration_tests/enarxcall.rs
+++ b/tests/integration_tests/enarxcall.rs
@@ -6,7 +6,6 @@ use sallyport::libc::ENOSYS;
 use std::arch::x86_64::{CpuidResult, __cpuid_count};
 
 use sallyport::guest::Handler;
-use sallyport::item::enarxcall::sgx;
 
 #[test]
 fn balloon_memory() {
@@ -34,7 +33,7 @@ fn cpuid() {
 fn get_sgx_quote() {
     run_test(1, [0xff; 1024], move |_, _, handler| {
         let report = Default::default();
-        let mut quote = [0u8; sgx::QUOTE_SIZE];
+        let mut quote = [0u8; 16];
         assert_eq!(handler.get_sgx_quote(&report, &mut quote), Err(ENOSYS));
     })
 }


### PR DESCRIPTION
The SGX quote size is not a constant.
Remove any SGX constants and introduce a new enarx sallyport call to get
the quote size.

Related: https://github.com/enarx/enarx/issues/1534

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
