### PR TITLE
fix: remove `libc` function bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ libc = { version = "0.2.119", default-features = false, optional = true }
 [dev-dependencies]
 serial_test = "0.6"
 memoffset = "0.6.5"
+libc = { version = "0.2.119" }
 
 [features]
 doc = [ "gdbstub", "libc" ]

--- a/src/guest/call/syscall/types/result/linux/x86_64.rs
+++ b/src/guest/call/syscall/types/result/linux/x86_64.rs
@@ -66,7 +66,9 @@ impl From<Result<isize>> for crate::Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::libc::{self, EPERM, F_GETFD};
+    use crate::libc::{EPERM, F_GETFD};
+
+    use libc;
 
     #[test]
     fn result() {

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -179,14 +179,6 @@ pub struct utsname {
     pub domainname: [c_char; 65],
 }
 
-extern "C" {
-    pub fn __errno_location() -> *mut c_int;
-    pub fn close(fd: c_int) -> c_int;
-    pub fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;
-    pub fn open(path: *const c_char, oflag: c_int, ...) -> c_int;
-    pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
-}
-
 pub const AF_INET: c_int = 2;
 pub const EACCES: c_int = 13;
 pub const EAGAIN: c_int = 11;

--- a/tests/integration_tests/syscall.rs
+++ b/tests/integration_tests/syscall.rs
@@ -2,17 +2,7 @@
 
 use super::{run_test, write_tcp};
 
-use sallyport::libc;
-use sallyport::libc::{
-    c_int, in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval, SYS_accept,
-    SYS_accept4, SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname,
-    SYS_listen, SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv, SYS_recvfrom,
-    SYS_sendto, SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES, EBADF, EBADFD,
-    EINVAL, ENOENT, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM, MSG_NOSIGNAL,
-    O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_WRONLY, SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET,
-    SO_RCVTIMEO, SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
-};
-
+use libc;
 use std::env::temp_dir;
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
@@ -26,6 +16,15 @@ use std::{mem, thread};
 
 use sallyport::guest::syscall::types::SockaddrOutput;
 use sallyport::guest::{syscall, Handler, Platform};
+use sallyport::libc::{
+    c_int, in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval, SYS_accept,
+    SYS_accept4, SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname,
+    SYS_listen, SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv, SYS_recvfrom,
+    SYS_sendto, SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES, EBADF, EBADFD,
+    EINVAL, ENOENT, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM, MSG_NOSIGNAL,
+    O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_WRONLY, SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET,
+    SO_RCVTIMEO, SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+};
 use serial_test::serial;
 
 fn syscall_socket<'a, 'b>(


### PR DESCRIPTION
Refs #126 

I still think we should rely on upstream `libc` in tests completely to test e.g. the validity of duplicated constants on particular platform the test is run on.

cc @rjzak 