### PR TITLE
refactor: use the new core::ffi typedefs directly

### DIFF
--- a/src/guest/call/enarxcall/passthrough.rs
+++ b/src/guest/call/enarxcall/passthrough.rs
@@ -4,8 +4,9 @@ use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector};
 use crate::item::enarxcall::Number;
-use crate::libc::c_void;
 use crate::Result;
+
+use core::ffi::c_void;
 
 /// Trait implemented by allocatable Enarx calls, which are passed through directly to the host and do
 /// not require custom handling logic.

--- a/src/guest/call/enarxcall/types/result.rs
+++ b/src/guest/call/enarxcall/types/result.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::libc::c_int;
-
+use core::ffi::c_int;
 use core::marker::PhantomData;
 
 pub const MAX_ERRNO: c_int = 4096;

--- a/src/guest/call/gdbcall/types/result.rs
+++ b/src/guest/call/gdbcall/types/result.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::libc::{c_int, EOVERFLOW};
+use crate::libc::EOVERFLOW;
 use crate::NULL;
 
+use core::ffi::c_int;
 use core::marker::PhantomData;
 
 pub const MAX_ERRNO: c_int = 4096;

--- a/src/guest/call/syscall/accept.rs
+++ b/src/guest/call/syscall/accept.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
-use crate::libc::{c_int, c_long, SYS_accept};
+use crate::libc::SYS_accept;
 use crate::{Result, NULL};
+
+use core::ffi::{c_int, c_long};
 
 pub struct Accept<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/accept4.rs
+++ b/src/guest/call/syscall/accept4.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
-use crate::libc::{c_int, c_long, SYS_accept4};
+use crate::libc::SYS_accept4;
 use crate::{Result, NULL};
+
+use core::ffi::{c_int, c_long};
 
 pub struct Accept4<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/alloc.rs
+++ b/src/guest/call/syscall/alloc.rs
@@ -3,8 +3,9 @@
 use super::super::alloc;
 use super::types::{self, CommittedAlloc, StagedAlloc};
 use crate::guest::alloc::{Allocator, Collector, Commit};
-use crate::libc::c_long;
 use crate::Result;
+
+use core::ffi::c_long;
 
 /// A generic syscall, which can be allocated within the block.
 ///
@@ -16,12 +17,14 @@ use crate::Result;
 /// # Examples
 ///
 /// ```rust
+/// # #![feature(c_size_t, core_ffi_c)]
 /// use sallyport::guest::alloc::{Allocator, Collector, Output};
 /// use sallyport::guest::call::types::Argv;
 /// use sallyport::guest::syscall::Alloc;
 /// use sallyport::Result;
 /// #
-/// # use sallyport::libc::{self, c_int, c_long, size_t};
+/// # use sallyport::libc;
+/// # use core::ffi::{c_int, c_long, c_size_t};
 ///
 /// pub struct Read<'a> {
 ///    pub fd: c_int,
@@ -32,11 +35,11 @@ use crate::Result;
 ///     const NUM: c_long = libc::SYS_read;
 ///
 ///     type Argv = Argv<3>;
-///     type Ret = size_t;
+///     type Ret = c_size_t;
 ///
 ///     type Staged = Output<'a, [u8], &'a mut [u8]>;
 ///     type Committed = Self::Staged;
-///     type Collected = Option<Result<size_t>>;
+///     type Collected = Option<Result<c_size_t>>;
 ///
 ///     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
 ///         let (buf, _) = Output::stage_slice_max(alloc, self.buf)?;

--- a/src/guest/call/syscall/bind.rs
+++ b/src/guest/call/syscall/bind.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{SockaddrInput, StagedSockaddrInput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Stage};
-use crate::libc::{c_int, c_long, SYS_bind};
+use crate::libc::SYS_bind;
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct Bind<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/clock_gettime.rs
+++ b/src/guest/call/syscall/clock_gettime.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Output};
-use crate::libc::{c_long, clockid_t, timespec, SYS_clock_gettime};
+use crate::libc::{clockid_t, timespec, SYS_clock_gettime};
 use crate::Result;
+
+use core::ffi::c_long;
 
 pub struct ClockGettime<'a> {
     pub clockid: clockid_t,

--- a/src/guest/call/syscall/connect.rs
+++ b/src/guest/call/syscall/connect.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::SockaddrInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input, Stage};
-use crate::libc::{c_int, c_long, SYS_connect};
+use crate::libc::SYS_connect;
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct Connect<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/epoll_ctl.rs
+++ b/src/guest/call/syscall/epoll_ctl.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
-use crate::libc::{c_int, c_long, epoll_event, SYS_epoll_ctl};
+use crate::libc::{epoll_event, SYS_epoll_ctl};
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct EpollCtl<'a> {
     pub epfd: c_int,

--- a/src/guest/call/syscall/epoll_pwait.rs
+++ b/src/guest/call/syscall/epoll_pwait.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Input, Output};
-use crate::libc::{c_int, c_long, epoll_event, sigset_t, SYS_epoll_pwait};
+use crate::libc::{epoll_event, sigset_t, SYS_epoll_pwait};
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct EpollPwait<'a> {
     pub epfd: c_int,

--- a/src/guest/call/syscall/epoll_wait.rs
+++ b/src/guest/call/syscall/epoll_wait.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
-use crate::libc::{c_int, c_long, epoll_event, SYS_epoll_wait};
+use crate::libc::{epoll_event, SYS_epoll_wait};
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct EpollWait<'a> {
     pub epfd: c_int,

--- a/src/guest/call/syscall/fcntl.rs
+++ b/src/guest/call/syscall/fcntl.rs
@@ -5,10 +5,12 @@ use super::super::types::Argv;
 use super::super::{MaybeAlloc, UnstagedMaybeAlloc};
 use super::PassthroughAlloc;
 use crate::libc::{
-    c_int, c_long, SYS_fcntl, EBADFD, EINVAL, F_GETFD, F_GETFL, F_SETFD, F_SETFL, O_APPEND, O_RDWR,
-    O_WRONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+    SYS_fcntl, EBADFD, EINVAL, F_GETFD, F_GETFL, F_SETFD, F_SETFL, O_APPEND, O_RDWR, O_WRONLY,
+    STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct Fcntl {
     pub fd: c_int,

--- a/src/guest/call/syscall/getsockname.rs
+++ b/src/guest/call/syscall/getsockname.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Stage};
-use crate::libc::{c_int, c_long, SYS_getsockname};
+use crate::libc::SYS_getsockname;
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct Getsockname<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/ioctl.rs
+++ b/src/guest/call/syscall/ioctl.rs
@@ -6,10 +6,12 @@ use crate::guest::alloc::{Allocator, Collect, Collector, InOut, Output};
 use crate::guest::call::alloc::kind;
 use crate::guest::call::{MaybeAlloc, UnstagedMaybeAlloc};
 use crate::libc::{
-    self, c_int, c_long, SYS_ioctl, EBADFD, EINVAL, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO,
-    STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ,
+    self, SYS_ioctl, EBADFD, EINVAL, ENOTTY, FIONBIO, FIONREAD, STDERR_FILENO, STDIN_FILENO,
+    STDOUT_FILENO, TIOCGWINSZ,
 };
 use crate::{Result, NULL};
+
+use core::ffi::{c_int, c_long};
 
 pub struct Ioctl<'a> {
     pub fd: c_int,

--- a/src/guest/call/syscall/nanosleep.rs
+++ b/src/guest/call/syscall/nanosleep.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Commit, Committer, InOut, Input, Output};
-use crate::libc::{c_long, timespec, SYS_nanosleep, EINTR};
+use crate::libc::{timespec, SYS_nanosleep, EINTR};
 use crate::{Result, NULL};
+
+use core::ffi::c_long;
 
 pub struct Nanosleep<'a> {
     pub req: &'a timespec,

--- a/src/guest/call/syscall/open.rs
+++ b/src/guest/call/syscall/open.rs
@@ -5,8 +5,10 @@ use super::super::types::Argv;
 use super::super::{MaybeAlloc, UnstagedMaybeAlloc};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
-use crate::libc::{c_int, c_long, mode_t, SYS_open, EACCES, O_CLOEXEC, O_RDONLY};
+use crate::libc::{mode_t, SYS_open, EACCES, O_CLOEXEC, O_RDONLY};
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct Open<'a> {
     pub pathname: &'a [u8],

--- a/src/guest/call/syscall/passthrough.rs
+++ b/src/guest/call/syscall/passthrough.rs
@@ -4,10 +4,12 @@ use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector};
 use crate::libc::{
-    c_int, c_long, SYS_close, SYS_dup, SYS_dup2, SYS_dup3, SYS_epoll_create1, SYS_eventfd2,
-    SYS_exit, SYS_exit_group, SYS_listen, SYS_socket, SYS_sync,
+    SYS_close, SYS_dup, SYS_dup2, SYS_dup3, SYS_epoll_create1, SYS_eventfd2, SYS_exit,
+    SYS_exit_group, SYS_listen, SYS_socket, SYS_sync,
 };
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 /// Trait implemented by allocatable syscalls, which are passed through directly to the host and do
 /// not require custom handling logic.
@@ -19,11 +21,13 @@ use crate::Result;
 ///
 /// # Example
 /// ```rust
+/// # #![feature(core_ffi_c)]
 /// use sallyport::guest::call::types::Argv;
 /// use sallyport::guest::syscall::PassthroughAlloc;
 /// use sallyport::Result;
 /// #
-/// # use sallyport::libc::{self, c_int, c_long};
+/// # use sallyport::libc;
+/// # use core::ffi::{c_int, c_long};
 ///
 /// pub struct Exit {
 ///     pub status: c_int,

--- a/src/guest/call/syscall/poll.rs
+++ b/src/guest/call/syscall/poll.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, InOut, Output};
-use crate::libc::{c_int, c_long, pollfd, SYS_poll};
+use crate::libc::{pollfd, SYS_poll};
 use crate::Result;
+
+use core::ffi::{c_int, c_long};
 
 pub struct Poll<'a> {
     pub fds: &'a mut [pollfd],

--- a/src/guest/call/syscall/read.rs
+++ b/src/guest/call/syscall/read.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
-use crate::libc::{c_int, c_long, size_t, SYS_read};
+use crate::libc::SYS_read;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Read<'a> {
     pub fd: c_int,
@@ -15,11 +17,11 @@ unsafe impl<'a> Alloc<'a> for Read<'a> {
     const NUM: c_long = SYS_read;
 
     type Argv = Argv<3>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = Output<'a, [u8], &'a mut [u8]>;
     type Committed = Self::Staged;
-    type Collected = Option<Result<size_t>>;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let (buf, _) = Output::stage_slice_max(alloc, self.buf)?;

--- a/src/guest/call/syscall/readv.rs
+++ b/src/guest/call/syscall/readv.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::{iov_len, Alloc};
 use crate::guest::alloc::{Allocator, Collector, CommitPassthrough, OutRef};
-use crate::libc::{c_int, c_long, size_t, SYS_read};
+use crate::libc::SYS_read;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Readv<T> {
     pub fd: c_int,
@@ -28,11 +30,11 @@ where
     const NUM: c_long = SYS_read;
 
     type Argv = Argv<3>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = StagedReadv<'a, &'a mut T>;
     type Committed = Self::Staged;
-    type Collected = Option<Result<size_t>>;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let buf = alloc.allocate_output_slice_max(iov_len(self.iovs as &T))?;

--- a/src/guest/call/syscall/recv.rs
+++ b/src/guest/call/syscall/recv.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Output};
-use crate::libc::{c_int, c_long, size_t, SYS_recvfrom};
+use crate::libc::SYS_recvfrom;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Recv<'a> {
     pub sockfd: c_int,
@@ -16,11 +18,11 @@ unsafe impl<'a> Alloc<'a> for Recv<'a> {
     const NUM: c_long = SYS_recvfrom;
 
     type Argv = Argv<4>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = Output<'a, [u8], &'a mut [u8]>;
     type Committed = Self::Staged;
-    type Collected = Option<Result<size_t>>;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let (buf, _) = Output::stage_slice_max(alloc, self.buf)?;

--- a/src/guest/call/syscall/recvfrom.rs
+++ b/src/guest/call/syscall/recvfrom.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{CommittedSockaddrOutput, SockaddrOutput, StagedSockaddrOutput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collect, Collector, Output, Stage};
-use crate::libc::{c_int, c_long, size_t, SYS_recvfrom};
+use crate::libc::SYS_recvfrom;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Recvfrom<'a, T> {
     pub sockfd: c_int,
@@ -18,7 +20,7 @@ unsafe impl<'a, T: Into<SockaddrOutput<'a>>> Alloc<'a> for Recvfrom<'a, T> {
     const NUM: c_long = SYS_recvfrom;
 
     type Argv = Argv<6>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = (
         Output<'a, [u8], &'a mut [u8]>, // buf
@@ -28,7 +30,7 @@ unsafe impl<'a, T: Into<SockaddrOutput<'a>>> Alloc<'a> for Recvfrom<'a, T> {
         Output<'a, [u8], &'a mut [u8]>, // buf
         CommittedSockaddrOutput<'a>,
     );
-    type Collected = Option<Result<size_t>>;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let src_addr = self.src_addr.into().stage(alloc)?;

--- a/src/guest/call/syscall/send.rs
+++ b/src/guest/call/syscall/send.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::StagedBytesInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
-use crate::libc::{c_int, c_long, size_t, SYS_sendto};
+use crate::libc::SYS_sendto;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Send<'a> {
     pub sockfd: c_int,
@@ -17,11 +19,11 @@ unsafe impl<'a> Alloc<'a> for Send<'a> {
     const NUM: c_long = SYS_sendto;
 
     type Argv = Argv<4>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = StagedBytesInput<'a>;
-    type Committed = size_t;
-    type Collected = Option<Result<size_t>>;
+    type Committed = c_size_t;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let (buf, _) = Input::stage_slice_max(alloc, self.buf)?;

--- a/src/guest/call/syscall/sendto.rs
+++ b/src/guest/call/syscall/sendto.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{SockaddrInput, StagedBytesInput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Input, Stage};
-use crate::libc::{c_int, c_long, size_t, SYS_sendto};
+use crate::libc::SYS_sendto;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Sendto<'a, T> {
     pub sockfd: c_int,
@@ -20,7 +22,7 @@ pub struct StagedSendto<'a> {
 }
 
 impl<'a> Commit for StagedSendto<'a> {
-    type Item = size_t;
+    type Item = c_size_t;
 
     fn commit(self, com: &impl Committer) -> Self::Item {
         self.dest_addr.commit(com);
@@ -32,11 +34,11 @@ unsafe impl<'a, T: Into<SockaddrInput<'a>>> Alloc<'a> for Sendto<'a, T> {
     const NUM: c_long = SYS_sendto;
 
     type Argv = Argv<6>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = StagedSendto<'a>;
-    type Committed = size_t;
-    type Collected = Option<Result<size_t>>;
+    type Committed = c_size_t;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let dest_addr = self.dest_addr.into().stage(alloc)?;

--- a/src/guest/call/syscall/setsockopt.rs
+++ b/src/guest/call/syscall/setsockopt.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::{SockoptInput, StagedSockoptInput};
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, Stage};
-use crate::libc::{c_int, c_long, SYS_setsockopt};
+use crate::libc::SYS_setsockopt;
 use crate::{Result, NULL};
+
+use core::ffi::{c_int, c_long};
 
 pub struct Setsockopt<T> {
     pub sockfd: c_int,

--- a/src/guest/call/syscall/stub.rs
+++ b/src/guest/call/syscall/stub.rs
@@ -3,12 +3,12 @@
 use super::super::Stub;
 use crate::guest::alloc::Collector;
 use crate::libc::{
-    c_char, c_int, c_uint, gid_t, pid_t, sigset_t, size_t, stack_t, stat, uid_t, utsname, EAGAIN,
-    EBADFD, EINVAL, ENOENT, GRND_NONBLOCK, GRND_RANDOM, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
-    S_IFIFO,
+    gid_t, pid_t, sigset_t, stack_t, stat, uid_t, utsname, EAGAIN, EBADFD, EINVAL, ENOENT,
+    GRND_NONBLOCK, GRND_RANDOM, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, S_IFIFO,
 };
 use crate::Result;
 
+use core::ffi::{c_char, c_int, c_size_t, c_uint};
 use core::mem;
 
 /// Fake GID returned by enarx.
@@ -124,7 +124,7 @@ pub struct Getrandom<'a> {
 }
 
 impl Stub for Getrandom<'_> {
-    type Ret = Result<size_t>;
+    type Ret = Result<c_size_t>;
 
     fn collect(self, _: &impl Collector) -> Self::Ret {
         if self.flags & !(GRND_NONBLOCK | GRND_RANDOM) != 0 {
@@ -167,7 +167,7 @@ pub struct Readlink<'a> {
 }
 
 impl Stub for Readlink<'_> {
-    type Ret = Option<Result<size_t>>;
+    type Ret = Option<Result<c_size_t>>;
 
     fn collect(self, _: &impl Collector) -> Self::Ret {
         match self.pathname {
@@ -188,7 +188,7 @@ pub struct RtSigprocmask<'a> {
     pub how: c_int,
     pub set: Option<&'a sigset_t>,
     pub oldset: Option<&'a mut sigset_t>,
-    pub sigsetsize: size_t,
+    pub sigsetsize: c_size_t,
 }
 
 impl Stub for RtSigprocmask<'_> {

--- a/src/guest/call/syscall/types/bytes.rs
+++ b/src/guest/call/syscall/types/bytes.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::guest::alloc::{Commit, Committer, Input};
-use crate::libc::size_t;
+
+use core::ffi::c_size_t;
 
 pub struct StagedBytesInput<'a>(pub Input<'a, [u8], &'a [u8]>);
 
 impl<'a> Commit for StagedBytesInput<'a> {
-    type Item = size_t;
+    type Item = c_size_t;
 
     #[inline]
     fn commit(self, com: &impl Committer) -> Self::Item {

--- a/src/guest/call/syscall/types/result/linux/x86_64.rs
+++ b/src/guest/call/syscall/types/result/linux/x86_64.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::libc::{c_int, EOVERFLOW};
+use crate::libc::EOVERFLOW;
 
+use core::ffi::c_int;
 use core::marker::PhantomData;
 
 pub const MAX_ERRNO: c_int = 4096;

--- a/src/guest/call/syscall/write.rs
+++ b/src/guest/call/syscall/write.rs
@@ -4,8 +4,10 @@ use super::super::types::Argv;
 use super::types::StagedBytesInput;
 use super::Alloc;
 use crate::guest::alloc::{Allocator, Collector, Input};
-use crate::libc::{c_int, c_long, size_t, SYS_write};
+use crate::libc::SYS_write;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Write<'a> {
     pub fd: c_int,
@@ -16,11 +18,11 @@ unsafe impl<'a> Alloc<'a> for Write<'a> {
     const NUM: c_long = SYS_write;
 
     type Argv = Argv<3>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = StagedBytesInput<'a>;
-    type Committed = size_t;
-    type Collected = Option<Result<size_t>>;
+    type Committed = c_size_t;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let (buf, _) = Input::stage_slice_max(alloc, self.buf)?;

--- a/src/guest/call/syscall/writev.rs
+++ b/src/guest/call/syscall/writev.rs
@@ -3,8 +3,10 @@
 use super::super::types::Argv;
 use super::{iov_len, Alloc};
 use crate::guest::alloc::{Allocator, Collector, Commit, Committer, InRef};
-use crate::libc::{c_int, c_long, size_t, SYS_write};
+use crate::libc::SYS_write;
 use crate::Result;
+
+use core::ffi::{c_int, c_long, c_size_t};
 
 pub struct Writev<T> {
     pub fd: c_int,
@@ -22,7 +24,7 @@ where
     for<'b> &'b T: IntoIterator<Item = &'b U>,
     U: AsRef<[u8]>,
 {
-    type Item = size_t;
+    type Item = c_size_t;
 
     fn commit(mut self, com: &impl Committer) -> Self::Item {
         let mut capacity = self.buf.len();
@@ -59,11 +61,11 @@ where
     const NUM: c_long = SYS_write;
 
     type Argv = Argv<3>;
-    type Ret = size_t;
+    type Ret = c_size_t;
 
     type Staged = StagedWritev<'a, &'a T>;
-    type Committed = size_t;
-    type Collected = Option<Result<size_t>>;
+    type Committed = c_size_t;
+    type Collected = Option<Result<c_size_t>>;
 
     fn stage(self, alloc: &mut impl Allocator) -> Result<(Self::Argv, Self::Staged)> {
         let buf = alloc.allocate_input_slice_max(iov_len(self.iovs))?;

--- a/src/guest/platform.rs
+++ b/src/guest/platform.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::syscall::types::SockaddrOutput;
-use crate::libc::{c_int, iovec, EINVAL};
+use crate::libc::{iovec, EINVAL};
 
+use core::ffi::c_int;
 use core::slice;
 
 /// Platform-specific functionality.

--- a/src/guest/tls.rs
+++ b/src/guest/tls.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::item::syscall::sigaction;
-use crate::libc::c_int;
+
+use core::ffi::c_int;
 
 pub(super) const SIGRTMAX: c_int = 64;
 

--- a/src/host/syscall.rs
+++ b/src/host/syscall.rs
@@ -2,11 +2,12 @@
 
 use super::{deref, deref_aligned};
 use crate::libc::{
-    self, c_long, epoll_event, pollfd, sigset_t, sockaddr_storage, socklen_t, timespec, EFAULT,
+    self, epoll_event, pollfd, sigset_t, sockaddr_storage, socklen_t, timespec, EFAULT,
 };
 use crate::{item, Result, NULL};
 
 use core::arch::asm;
+use core::ffi::c_long;
 use core::mem::align_of;
 use core::ptr::{null, null_mut};
 

--- a/src/item/syscall.rs
+++ b/src/item/syscall.rs
@@ -2,8 +2,7 @@
 
 //! System call item definitions
 
-use crate::libc::c_int;
-
+use core::ffi::c_int;
 use core::mem::size_of;
 
 /// Payload of an [`Item`](super::Item) of [`Kind::Syscall`](super::Kind::Syscall).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub mod libc;
 pub mod util;
 
 /// Error type used within this crate.
-pub type Error = crate::libc::c_int;
+pub type Error = core::ffi::c_int;
 
 /// Result type returned by functionality exposed by this crate.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -15,14 +15,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-pub type c_char = core::ffi::c_char;
-pub type c_int = core::ffi::c_int;
-pub type c_long = core::ffi::c_long;
-pub type c_short = core::ffi::c_short;
-pub type c_uint = core::ffi::c_uint;
-pub type c_ulong = core::ffi::c_ulong;
-pub type c_void = core::ffi::c_void;
-pub type size_t = core::ffi::c_size_t;
+use core::ffi::{c_char, c_int, c_long, c_short, c_size_t, c_uint, c_ulong, c_void};
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;
@@ -54,7 +47,7 @@ pub struct epoll_event {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct iovec {
     pub iov_base: *mut c_void,
-    pub iov_len: size_t,
+    pub iov_len: c_size_t,
 }
 
 #[repr(C)]
@@ -114,7 +107,7 @@ pub struct sockaddr_in6 {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct sockaddr_storage {
     pub ss_family: sa_family_t,
-    __ss_align: size_t,
+    __ss_align: c_size_t,
     __ss_pad2: [u8; 128 - 2 * 8],
 }
 
@@ -130,7 +123,7 @@ pub struct sockaddr_un {
 pub struct stack_t {
     pub ss_sp: *mut c_void,
     pub ss_flags: c_int,
-    pub ss_size: size_t,
+    pub ss_size: c_size_t,
 }
 
 #[repr(C)]

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -3,6 +3,7 @@
 pub mod enarxcall;
 pub mod syscall;
 
+use core::ffi::{c_int, c_size_t, c_ulong, c_void};
 use core::slice;
 use std::io::Write;
 use std::net::{TcpStream, ToSocketAddrs};
@@ -11,7 +12,7 @@ use std::thread;
 
 use sallyport::guest::{Handler, Platform, ThreadLocalStorage};
 use sallyport::item::Block;
-use sallyport::libc::{c_int, c_ulong, c_void, off_t, size_t, EINVAL, ENOSYS};
+use sallyport::libc::{off_t, EINVAL, ENOSYS};
 use sallyport::util::ptr;
 use sallyport::{host, Result};
 
@@ -90,7 +91,7 @@ impl<const N: usize> Handler for TestHandler<N> {
         &mut self,
         _platform: &impl Platform,
         _addr: NonNull<c_void>,
-        _length: size_t,
+        _length: c_size_t,
         _advice: c_int,
     ) -> Result<()> {
         Err(ENOSYS)
@@ -100,7 +101,7 @@ impl<const N: usize> Handler for TestHandler<N> {
         &mut self,
         _platform: &impl Platform,
         _addr: Option<NonNull<c_void>>,
-        _length: size_t,
+        _length: c_size_t,
         _prot: c_int,
         _flags: c_int,
         _fd: c_int,
@@ -113,7 +114,7 @@ impl<const N: usize> Handler for TestHandler<N> {
         &mut self,
         _platform: &impl Platform,
         _addr: NonNull<c_void>,
-        _len: size_t,
+        _len: c_size_t,
         _prot: c_int,
     ) -> Result<()> {
         Err(ENOSYS)
@@ -123,7 +124,7 @@ impl<const N: usize> Handler for TestHandler<N> {
         &mut self,
         _platform: &impl Platform,
         _addr: NonNull<c_void>,
-        _length: size_t,
+        _length: c_size_t,
     ) -> Result<()> {
         Err(ENOSYS)
     }

--- a/tests/integration_tests/syscall.rs
+++ b/tests/integration_tests/syscall.rs
@@ -2,6 +2,7 @@
 
 use super::{run_test, write_tcp};
 
+use core::ffi::c_int;
 use libc;
 use std::env::temp_dir;
 use std::ffi::CString;
@@ -17,13 +18,13 @@ use std::{mem, thread};
 use sallyport::guest::syscall::types::SockaddrOutput;
 use sallyport::guest::{syscall, Handler, Platform};
 use sallyport::libc::{
-    c_int, in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval, SYS_accept,
-    SYS_accept4, SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname,
-    SYS_listen, SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv, SYS_recvfrom,
-    SYS_sendto, SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES, EBADF, EBADFD,
-    EINVAL, ENOENT, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM, MSG_NOSIGNAL,
-    O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_WRONLY, SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET,
-    SO_RCVTIMEO, SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+    in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval, SYS_accept, SYS_accept4,
+    SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname, SYS_listen,
+    SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv, SYS_recvfrom, SYS_sendto,
+    SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES, EBADF, EBADFD, EINVAL,
+    ENOENT, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM, MSG_NOSIGNAL, O_APPEND,
+    O_CREAT, O_RDONLY, O_RDWR, O_WRONLY, SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET, SO_RCVTIMEO,
+    SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 use serial_test::serial;
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,1 +1,3 @@
+#![feature(c_size_t, core_ffi_c)]
+
 mod integration_tests;


### PR DESCRIPTION
Closes https://github.com/enarx/sallyport/issues/133 .

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
