### PR TITLE
test: use `libc` constants in tests for #126

### DIFF
--- a/src/guest/call/syscall/tests.rs
+++ b/src/guest/call/syscall/tests.rs
@@ -7,10 +7,11 @@ use crate::guest::syscall::types::SockaddrOutput;
 use crate::guest::Call;
 use crate::item;
 use crate::item::syscall;
-use crate::libc::{socklen_t, SYS_exit, SYS_recvfrom, AF_INET, ENOSYS};
+use crate::libc::socklen_t;
 use crate::NULL;
 
 use core::mem::size_of;
+use libc::{SYS_exit, SYS_recvfrom, AF_INET, ENOSYS};
 
 fn assert_call<'a, K: kind::Kind, T: Call<'a, K>, const N: usize>(
     call: T,

--- a/src/guest/call/syscall/types/result/linux/x86_64.rs
+++ b/src/guest/call/syscall/types/result/linux/x86_64.rs
@@ -67,9 +67,7 @@ impl From<Result<isize>> for crate::Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::libc::{EPERM, F_GETFD};
-
-    use libc;
+    use libc::{self, EPERM, F_GETFD};
 
     #[test]
     fn result() {

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -104,7 +104,10 @@ mod tests {
     use crate::item::{gdbcall, Gdbcall, Syscall};
     use crate::NULL;
 
-    use crate::libc::*;
+    use libc::{
+        SYS_close, SYS_dup2, SYS_fcntl, SYS_read, SYS_sync, SYS_write, EFAULT, ENOSYS, EOVERFLOW,
+        F_GETFD, STDIN_FILENO, STDOUT_FILENO,
+    };
     use std::fmt::Debug;
 
     struct DerefTestCase<T> {

--- a/src/item/block.rs
+++ b/src/item/block.rs
@@ -148,7 +148,7 @@ impl<'a> Iterator for BlockIterator<'a> {
 mod tests {
     use super::super::HEADER_USIZE_COUNT;
     use super::*;
-    use crate::libc::{SYS_exit, SYS_read, ENOSYS};
+    use libc::{SYS_exit, SYS_read, ENOSYS};
 
     #[test]
     fn block_size_hint() {

--- a/tests/integration_tests/enarxcall.rs
+++ b/tests/integration_tests/enarxcall.rs
@@ -2,7 +2,7 @@
 
 use super::run_test;
 
-use sallyport::libc::ENOSYS;
+use libc::ENOSYS;
 use std::arch::x86_64::{CpuidResult, __cpuid_count};
 
 use sallyport::guest::Handler;

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -5,6 +5,7 @@ pub mod syscall;
 
 use core::ffi::{c_int, c_size_t, c_ulong, c_void};
 use core::slice;
+use libc::{EINVAL, ENOSYS};
 use std::io::Write;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::ptr::NonNull;
@@ -12,7 +13,7 @@ use std::thread;
 
 use sallyport::guest::{Handler, Platform, ThreadLocalStorage};
 use sallyport::item::Block;
-use sallyport::libc::{off_t, EINVAL, ENOSYS};
+use sallyport::libc::off_t;
 use sallyport::util::ptr;
 use sallyport::{host, Result};
 

--- a/tests/integration_tests/syscall.rs
+++ b/tests/integration_tests/syscall.rs
@@ -4,6 +4,14 @@ use super::{run_test, write_tcp};
 
 use core::ffi::c_int;
 use libc;
+use libc::{
+    SYS_accept, SYS_accept4, SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom,
+    SYS_getsockname, SYS_listen, SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv,
+    SYS_recvfrom, SYS_sendto, SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES,
+    EBADF, EBADFD, EINVAL, ENOENT, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM,
+    MSG_NOSIGNAL, O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_WRONLY, SOCK_CLOEXEC, SOCK_STREAM,
+    SOL_SOCKET, SO_RCVTIMEO, SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+};
 use std::env::temp_dir;
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
@@ -17,15 +25,7 @@ use std::{mem, thread};
 
 use sallyport::guest::syscall::types::SockaddrOutput;
 use sallyport::guest::{syscall, Handler, Platform};
-use sallyport::libc::{
-    in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval, SYS_accept, SYS_accept4,
-    SYS_bind, SYS_close, SYS_fcntl, SYS_fstat, SYS_getrandom, SYS_getsockname, SYS_listen,
-    SYS_nanosleep, SYS_open, SYS_read, SYS_readlink, SYS_readv, SYS_recvfrom, SYS_sendto,
-    SYS_setsockopt, SYS_socket, SYS_write, SYS_writev, AF_INET, EACCES, EBADF, EBADFD, EINVAL,
-    ENOENT, ENOSYS, F_GETFD, F_GETFL, F_SETFD, F_SETFL, GRND_RANDOM, MSG_NOSIGNAL, O_APPEND,
-    O_CREAT, O_RDONLY, O_RDWR, O_WRONLY, SOCK_CLOEXEC, SOCK_STREAM, SOL_SOCKET, SO_RCVTIMEO,
-    SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
-};
+use sallyport::libc::{in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval};
 use serial_test::serial;
 
 fn syscall_socket<'a, 'b>(


### PR DESCRIPTION
Trying to close #126. There are some unchanged tests which didn't use the internal libc for constants.

Signed-off-by: Richard Zak <richard@profian.com>

