### PR TITLE
test: increase coverage

### DIFF
--- a/src/guest/alloc/tests.rs
+++ b/src/guest/alloc/tests.rs
@@ -8,9 +8,9 @@ use core::mem::size_of;
 fn assert_block_eq<const N: usize>(got: [usize; N], expected: [usize; N]) {
     #[inline]
     fn format(iter: impl IntoIterator<Item = impl LowerHex>) -> String {
-        iter.into_iter().fold(String::from("\n[\n"), |s, el| {
-            format!("{} {:#018x},\n", s, el)
-        }) + "]\n"
+        iter.into_iter()
+            .fold("\n[\n".into(), |s, el| format!("{} {:#018x},\n", s, el))
+            + "]\n"
     }
     assert_eq!(
         got,

--- a/src/guest/handler.rs
+++ b/src/guest/handler.rs
@@ -462,12 +462,6 @@ pub trait Handler {
         })?
     }
 
-    /// Executes [`sigaltstack`](https://man7.org/linux/man-pages/man2/sigaltstack.2.html) syscall akin to [`libc::sigaltstack`].
-    #[inline]
-    fn sigaltstack(&mut self, ss: Option<&stack_t>, old_ss: Option<&mut stack_t>) -> Result<()> {
-        self.execute(syscall::Sigaltstack { ss, old_ss })?
-    }
-
     /// Executes [`send`](https://man7.org/linux/man-pages/man2/send.2.html) syscall akin to [`libc::send`].
     #[inline]
     fn send(&mut self, sockfd: c_int, buf: &[u8], flags: c_int) -> Result<c_size_t> {
@@ -514,6 +508,12 @@ pub trait Handler {
     #[inline]
     fn set_tid_address(&mut self, tidptr: &mut c_int) -> Result<pid_t> {
         self.execute(syscall::SetTidAddress { tidptr })
+    }
+
+    /// Executes [`sigaltstack`](https://man7.org/linux/man-pages/man2/sigaltstack.2.html) syscall akin to [`libc::sigaltstack`].
+    #[inline]
+    fn sigaltstack(&mut self, ss: Option<&stack_t>, old_ss: Option<&mut stack_t>) -> Result<()> {
+        self.execute(syscall::Sigaltstack { ss, old_ss })?
     }
 
     /// Executes [`socket`](https://man7.org/linux/man-pages/man2/socket.2.html) syscall akin to [`libc::socket`].

--- a/src/item/block.rs
+++ b/src/item/block.rs
@@ -146,9 +146,12 @@ impl<'a> Iterator for BlockIterator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::HEADER_USIZE_COUNT;
     use super::*;
+    use crate::item::Header;
+
     use libc::{SYS_exit, SYS_read, ENOSYS};
+
+    const HEADER_USIZE_COUNT: usize = size_of::<Header>() / size_of::<usize>();
 
     #[test]
     fn block_size_hint() {

--- a/src/util/ptr.rs
+++ b/src/util/ptr.rs
@@ -2,12 +2,45 @@
 
 //! Utility functions for pointers
 
+use core::mem::align_of;
+
 /// Validates that `ptr` is aligned and non-null
 ///
 /// Returns `Some(ptr)`, if so and `None` if not.
 pub fn is_aligned_non_null<T>(ptr: usize) -> Option<usize> {
-    if ptr == 0 || ptr % core::mem::align_of::<T>() != 0 {
+    if ptr == 0 || ptr % align_of::<T>() != 0 {
         return None;
     }
     Some(ptr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_aligned_non_null() {
+        assert_eq!(super::is_aligned_non_null::<u8>(0), None);
+        assert_eq!(super::is_aligned_non_null::<u64>(0), None);
+
+        assert_eq!(
+            super::is_aligned_non_null::<u8>(align_of::<u16>()),
+            Some(align_of::<u16>())
+        );
+        assert_eq!(
+            super::is_aligned_non_null::<u16>(align_of::<u16>()),
+            Some(align_of::<u16>())
+        );
+        assert_eq!(super::is_aligned_non_null::<u32>(align_of::<u16>()), None);
+        assert_eq!(super::is_aligned_non_null::<u64>(align_of::<u16>()), None);
+
+        assert_eq!(
+            super::is_aligned_non_null::<u64>(align_of::<u64>()),
+            Some(align_of::<u64>())
+        );
+        assert_eq!(
+            super::is_aligned_non_null::<u128>(align_of::<u64>()),
+            Some(align_of::<u64>())
+        );
+    }
 }

--- a/tests/integration_tests/gdbcall.rs
+++ b/tests/integration_tests/gdbcall.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::run_test;
+
+use libc::ENOSYS;
+
+use sallyport::guest::Handler;
+
+#[test]
+fn gdb_flush() {
+    run_test(1, [0xff; 16], move |_, _, handler| {
+        assert_eq!(handler.gdb_flush(), Err(ENOSYS));
+    })
+}
+
+#[test]
+fn gdb_on_session_start() {
+    run_test(1, [0xff; 16], move |_, _, handler| {
+        assert_eq!(handler.gdb_on_session_start(), Err(ENOSYS));
+    })
+}
+
+#[test]
+fn gdb_peek() {
+    run_test(1, [0xff; 16], move |_, _, handler| {
+        assert_eq!(handler.gdb_peek(), Err(ENOSYS));
+    })
+}
+
+#[test]
+fn gdb_read() {
+    run_test(1, [0xff; 16], move |_, _, handler| {
+        assert_eq!(handler.gdb_read(), Err(ENOSYS));
+    })
+}
+
+#[test]
+fn gdb_write() {
+    run_test(1, [0xff; 16], move |_, _, handler| {
+        assert_eq!(handler.gdb_write(0xff), Err(ENOSYS));
+    })
+}
+
+#[test]
+fn gdb_write_all() {
+    run_test(1, [0xff; 16], move |_, _, handler| {
+        assert_eq!(handler.gdb_write_all(&[0xfe, 0xed]), Err(ENOSYS));
+    })
+}

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod enarxcall;
+pub mod gdbcall;
 pub mod syscall;
 
 use core::ffi::{c_int, c_size_t, c_ulong, c_void};
 use core::slice;
 use libc::{EINVAL, ENOSYS};
 use std::io::Write;
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{TcpStream, ToSocketAddrs, UdpSocket};
 use std::ptr::NonNull;
 use std::thread;
 
@@ -150,6 +151,16 @@ where
             .join()
             .expect(&format!("couldn't join test iteration {} thread", i))
     }
+}
+
+pub fn recv_udp(sock: UdpSocket, expected: &str) {
+    let mut buf = Vec::with_capacity(expected.len());
+    buf.resize(expected.len(), 0);
+    assert_eq!(
+        sock.recv(&mut buf).expect("couldn't recv data"),
+        expected.len()
+    );
+    assert_eq!(buf, expected.as_bytes());
 }
 
 pub fn write_tcp(addr: impl ToSocketAddrs, buf: &[u8]) {

--- a/tests/integration_tests/syscall.rs
+++ b/tests/integration_tests/syscall.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::integration_tests::recv_udp;
 use super::{run_test, write_tcp};
+use crate::integration_tests::recv_udp;
 
 use core::ffi::{c_char, c_int};
 use libc::{
@@ -929,7 +929,7 @@ fn tcp_server() {
 
         const EXPECTED: &str = "tcp";
         let client = thread::Builder::new()
-            .name(String::from("client"))
+            .name("client".into())
             .spawn(move || {
                 write_tcp(
                     ("127.0.0.1", u16::from_be(addr.sin_port)),
@@ -1039,7 +1039,7 @@ fn recvfrom() {
         let src_port = src_socket.local_addr().unwrap().port();
 
         let client = thread::Builder::new()
-            .name(String::from("client"))
+            .name("client".into())
             .spawn(move || {
                 assert_eq!(
                     src_socket
@@ -1216,7 +1216,7 @@ fn send() {
         let dest_addr = dest_socket.local_addr().unwrap();
 
         let server = thread::Builder::new()
-            .name(String::from("server"))
+            .name("server".into())
             .spawn(move || recv_udp(dest_socket, EXPECTED))
             .expect("couldn't spawn server thread");
 
@@ -1263,7 +1263,7 @@ fn sendto() {
         let dest_port = dest_socket.local_addr().unwrap().port();
 
         let server = thread::Builder::new()
-            .name(String::from("server"))
+            .name("server".into())
             .spawn(move || recv_udp(dest_socket, EXPECTED))
             .expect("couldn't spawn server thread");
 


### PR DESCRIPTION
Refs enarx/enarx#1730 

- Remove unused constant definition
- Add unit tests
- Add integration tests
- Refactor some tests for consistency and test coverage increase
- Add `recv_udp` test utility
- Fix `rt_sigaction` handling via `syscall` method


81.40% coverage, 2310/2838 lines covered