### PR TITLE
feat: default mremap() implementation

### DIFF
--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -12,7 +12,6 @@ use std::net::{TcpStream, ToSocketAddrs, UdpSocket};
 use std::ptr::NonNull;
 use std::thread;
 
-use sallyport::guest::syscall::types::MremapFlags;
 use sallyport::guest::{Handler, Platform, ThreadLocalStorage};
 use sallyport::item::Block;
 use sallyport::libc::off_t;
@@ -120,17 +119,6 @@ impl<const N: usize> Handler for TestHandler<N> {
         _len: c_size_t,
         _prot: c_int,
     ) -> Result<()> {
-        Err(ENOSYS)
-    }
-
-    fn mremap(
-        &mut self,
-        _platform: &impl Platform,
-        _old_address: NonNull<c_void>,
-        _old_size: c_size_t,
-        _new_size: c_size_t,
-        _flags: Option<MremapFlags>,
-    ) -> Result<NonNull<c_void>> {
         Err(ENOSYS)
     }
 


### PR DESCRIPTION
A simple fallback implementation, which just unmaps or copies over data
to a newly mapped region.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
